### PR TITLE
Run copy_to_jekyll less often for now

### DIFF
--- a/.github/workflows/copy_to_jekyll.yml
+++ b/.github/workflows/copy_to_jekyll.yml
@@ -3,14 +3,14 @@ name: Copy files to jekyll repo
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '14 3 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  pubmed:
+  copy_to_jekyll:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
With 30s per run and 144 runs per day this job alone comes down to ~2160 minutes per month which is above [the limit for GitHub Free](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes). This runs it once per day, at a semi-random time to avoid any peaks in GH Action usage (e.g. at 0:00 UTC).