### PR TITLE
WP5186: add circualting menadione

### DIFF
--- a/pathways/WP5186/WP5186.gpml
+++ b/pathways/WP5186/WP5186.gpml
@@ -42,7 +42,7 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Comment>menadione, synthetic form of vitamin K; interferes with glutathione function.</Comment>
     <Comment>"NQO1 competes with enzymes that redox cycle vitamin K and catalyzes two-electron reduction of vitamin K3 to hydroquinone. This skips formation of semiquinone and ROS. Therefore, NQO1 metabolically detoxifies vitamin K3 and protects cells against oxidative stress and other adverse effects." [PMID:18374191]</Comment>
     <Comment>This reaction has been described in more detail in a mouse study [PMID:24015818]</Comment>
-    <Graphics CenterX="89.0" CenterY="512.0" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="97.59422958870488" CenterY="598.5561694290967" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
     <Xref Database="ChEBI" ID="CHEBI:28869" />
   </DataNode>
   <DataNode TextLabel="Vitamin K1" GraphId="c1b43" Type="Metabolite">
@@ -58,7 +58,7 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Xref Database="Uniprot-TrEMBL" ID="P08709" />
   </DataNode>
   <DataNode TextLabel="disulfides" GraphId="c609e" Type="Metabolite">
-    <Graphics CenterX="466.9820872731532" CenterY="524.838899187755" Width="49.23551312248211" Height="16.98886829115672" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="464.5770848681508" CenterY="524.5016959494498" Width="49.23551312248211" Height="16.98886829115672" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
     <Xref Database="ChEBI" ID="CHEBI:48343" />
   </DataNode>
   <DataNode TextLabel="Vitamin K epoxide&#xA;(VKO)" GraphId="c964e" Type="Metabolite">
@@ -78,7 +78,7 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Xref Database="" ID="" />
   </DataNode>
   <DataNode TextLabel="NADPH" GraphId="cce0d" Type="Metabolite">
-    <Graphics CenterX="68.08238064048794" CenterY="426.1927829500173" Width="41.38994309621074" Height="17.873765191953023" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="63.78526584613586" CenterY="536.0761469770275" Width="41.38994309621074" Height="17.873765191953023" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
     <Xref Database="HMDB" ID="HMDB00221" />
   </DataNode>
   <DataNode TextLabel="gamma-carboxyglutamate" GraphId="cd034" Type="Metabolite" GroupRef="db2f9">
@@ -95,20 +95,24 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Xref Database="Uniprot-TrEMBL" ID="P07225" />
   </DataNode>
   <DataNode TextLabel="dithiols" GraphId="d28e1" Type="Metabolite">
-    <Graphics CenterX="466.98208727315324" CenterY="564.5517988125905" Width="49.23551312248211" Height="16.98886829115672" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="464.57708486815073" CenterY="564.5517988125905" Width="49.23551312248211" Height="16.98886829115672" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
     <Xref Database="ChEBI" ID="CHEBI:23853" />
   </DataNode>
   <DataNode TextLabel="Warfarin" GraphId="d3828" Type="Metabolite">
-    <Graphics CenterX="557.0218526781556" CenterY="437.58281387533026" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="362.110864341753" CenterY="421.55273407177" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
     <Xref Database="HMDB" ID="HMDB0001935" />
   </DataNode>
   <DataNode TextLabel="NADP+" GraphId="d47ab" Type="Metabolite">
-    <Graphics CenterX="80.16280780541533" CenterY="383.9520062929125" Width="41.389943096210736" Height="17.873765191952998" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="66.04371633825697" CenterY="509.18220887118093" Width="41.389943096210736" Height="17.873765191952998" ZOrder="32768" FontSize="8" Valign="Middle" Color="0000ff" />
     <Xref Database="ChEBI" ID="CHEBI:18009" />
   </DataNode>
   <DataNode TextLabel="Coagulation factor IX" GraphId="d61f9" Type="Protein" GroupRef="f5cb5">
     <Graphics CenterX="158.10086188727539" CenterY="209.27892813641893" Width="210.20172377455077" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="P00740" />
+  </DataNode>
+  <DataNode TextLabel="Menadiol" GraphId="d962f" Type="Metabolite">
+    <Graphics CenterX="123.4979132929881" CenterY="478.3019459533508" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
+    <Xref Database="ChEBI" ID="CHEBI:6746" />
   </DataNode>
   <DataNode TextLabel="Vitamin K&#xA;(VK)" GraphId="dd705" Type="Metabolite">
     <Comment>Group of metabolites known as Vitamin K, which are structurally similar and found in food.</Comment>
@@ -125,19 +129,23 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
   </DataNode>
   <DataNode TextLabel="VKORC1" GraphId="eb076" Type="Protein" GroupRef="d63fe">
     <Comment>"Catalytic subunit of the vitamin K epoxide reductase (VKOR) complex which reduces inactive vitamin K 2,3-epoxide to active vitamin K" Source: https://www.uniprot.org/uniprotkb/Q9BQB6/entry</Comment>
-    <Graphics CenterX="376.87582421750034" CenterY="428.3810769955949" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="552.8758242175004" CenterY="420.3810769955949" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="Q9BQB6" />
   </DataNode>
   <DataNode TextLabel="NQO1" GraphId="f4e1c" Type="Protein">
     <Comment>AKA NAD(P)H dehydrogenase [quinone] 1</Comment>
-    <Graphics CenterX="166.8628979156342" CenterY="451.4520957739229" Width="60.23311752332621" Height="24.999999999999986" ZOrder="32768" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="188.96234542944637" CenterY="533.7111504086678" Width="60.23311752332621" Height="24.999999999999986" ZOrder="32768" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="P15559" />
   </DataNode>
   <DataNode TextLabel="Vitamin K hydroquinone&#xA;(VKH2)" GraphId="fb891" Type="Metabolite">
     <Comment>AKA phyllohydroquinone,  phylloquinol, VKH2</Comment>
     <Comment>cofactor for the enzyme γ-glutamyl carboxylase (GGCX)</Comment>
-    <Graphics CenterX="219.99859031878043" CenterY="389.13744746106664" Width="171.99718063756086" Height="37.32251396975231" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
+    <Graphics CenterX="219.99859031878043" CenterY="389.75132100311697" Width="171.99718063756086" Height="37.32251396975231" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
     <Xref Database="ChEBI" ID="CHEBI:28433" />
+  </DataNode>
+  <DataNode TextLabel="UBIAD1" GraphId="fc3ab" Type="GeneProduct">
+    <Graphics CenterX="71.66907166907188" CenterY="424.8058060212756" Width="61.56806156806147" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" />
+    <Xref Database="Entrez Gene" ID="29914" />
   </DataNode>
   <DataNode TextLabel="Vitamin K-dependent protein Z" GraphId="fd3af" Type="Protein" GroupRef="f5cb5">
     <Graphics CenterX="158.10086188727539" CenterY="340.2789281364189" Width="210.20172377455077" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" />
@@ -231,12 +239,12 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
   </DataNode>
   <DataNode TextLabel="VKORC1L1" GraphId="fe331" Type="Protein" GroupRef="d63fe">
     <Comment>"Can reduce inactive vitamin K 2,3-epoxide to active vitamin K (in vitro)" Source: https://www.uniprot.org/uniprotkb/Q8N0U8/entry</Comment>
-    <Graphics CenterX="376.87582421750034" CenterY="453.3810769955949" Width="90.0" Height="25.0" ZOrder="32797" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="553.1418174834937" CenterY="453.5330731475911" Width="90.0" Height="25.0" ZOrder="32797" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="Q8N0U8" />
   </DataNode>
   <DataNode TextLabel="VKOR" GraphId="b5c12" Type="Protein">
     <Comment>Vitamin-K-epoxide reductase</Comment>
-    <Graphics CenterX="466.9820872731531" CenterY="490.6471525342086" Width="60.23311752332622" Height="25.0" ZOrder="32798" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="464.57708486815073" CenterY="478.62214050919664" Width="60.23311752332622" Height="25.0" ZOrder="32798" FontSize="12" Valign="Middle" />
     <Xref Database="Enzyme Nomenclature" ID="1.17.4.4" />
   </DataNode>
   <DataNode TextLabel="Mqn" GraphId="ef4d2" Type="Pathway">
@@ -246,13 +254,13 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Graphics CenterX="364.02118308598807" CenterY="860.3258145363407" Width="50.144440047487095" Height="25.0" ZOrder="32799" FontWeight="Bold" FontSize="12" Valign="Middle" Color="14961e" />
     <Xref Database="" ID="" />
   </DataNode>
-  <DataNode TextLabel="Vitamin K1" GraphId="b817f" Type="Metabolite">
+  <DataNode TextLabel="Vitamin K" GraphId="b817f" Type="Metabolite">
     <Comment>AKA phylloquinone, VK</Comment>
     <Comment>Natural vitamer</Comment>
     <Comment>Made in plants (with high concentrations in green leafy vegetables).</Comment>
     <Comment>Converted by bacteria in gut microbiome to MK-4.</Comment>
     <Graphics CenterX="461.9949738415153" CenterY="634.1826769023518" Width="90.0" Height="25.0" ZOrder="32805" FontSize="12" Valign="Middle" Color="0000ff" />
-    <Xref Database="ChEBI" ID="CHEBI:18067" />
+    <Xref Database="ChEBI" ID="CHEBI:28384" />
   </DataNode>
   <DataNode TextLabel="LOOH" GraphId="d994c" Type="Metabolite">
     <Comment>lipid hydroperoxides (LOOH)</Comment>
@@ -260,31 +268,90 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Graphics CenterX="312.60177318899053" CenterY="602.041840602358" Width="50.84795321637428" Height="25.0" ZOrder="32807" FontSize="12" Valign="Middle" Color="0000ff" />
     <Xref Database="Wikidata" ID="Q76617139" />
   </DataNode>
+  <DataNode TextLabel="geranylgeranyl&#xA;diphosphate" GraphId="b8071" Type="Metabolite">
+    <Graphics CenterX="158.2644809791624" CenterY="446.37592357022464" Width="68.78306878306859" Height="25.631298389511358" ZOrder="32811" FontSize="8" Valign="Middle" Color="0000ff" />
+    <Xref Database="ChEBI" ID="CHEBI:58756" />
+  </DataNode>
+  <DataNode TextLabel="Dietary&#xA;Vitamin K1" GraphId="eb473" Type="Metabolite">
+    <Comment>AKA phylloquinone, VK</Comment>
+    <Comment>Natural vitamer</Comment>
+    <Comment>Made in plants (with high concentrations in green leafy vegetables).</Comment>
+    <Comment>Converted by bacteria in gut microbiome to MK-4.</Comment>
+    <Graphics CenterX="114.31552376564997" CenterY="698.9031596708921" Width="90.0" Height="29.094265453537407" ZOrder="32812" FontSize="12" Valign="Middle" Color="0000ff" />
+    <Xref Database="ChEBI" ID="CHEBI:18067" />
+  </DataNode>
   <Interaction GraphId="ide2cc9d80">
     <Graphics ZOrder="-5" LineThickness="1.0">
-      <Point GraphId="ebdc3" X="451.9238078923216" Y="503.1471525342086" GraphRef="b5c12" RelX="-0.5" RelY="1.0" />
-      <Point GraphId="ff732" X="370.9283607008336" Y="523.8034107438635" GraphRef="fc869" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="449.5188054873192" Y="491.12214050919664" GraphRef="b5c12" RelX="-0.5" RelY="1.0" />
+      <Point X="370.9283607008336" Y="524.0843363836856" GraphRef="fc869" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idea307b2a">
     <Graphics ZOrder="-4" LineThickness="1.0">
-      <Point GraphId="d127c" X="151.80461853480264" Y="438.9520957739229" GraphRef="f4e1c" RelX="-0.5" RelY="-1.0" />
-      <Point GraphId="f5f74" X="116.89778665484667" Y="431.080645657434" GraphRef="ad691" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="158.84578666778327" Y="533.7111504086678" GraphRef="f4e1c" RelX="-1.0" RelY="0.0" />
+      <Point X="114.02872299300984" Y="525.6224903695626" GraphRef="ad691" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id66dd302c">
     <Graphics ZOrder="-2" LineThickness="1.0">
-      <Point GraphId="fa7a2" X="466.9820872731531" Y="503.1471525342086" GraphRef="b5c12" RelX="0.0" RelY="1.0" />
-      <Point GraphId="e3e30" X="588.9567014777498" Y="531.077894707893" GraphRef="fce24" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="464.57708486815073" Y="491.12214050919664" GraphRef="b5c12" RelX="0.0" RelY="1.0" />
+      <Point X="594.6982252738205" Y="523.8552729119554" GraphRef="fce24" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction>
+    <BiopaxRef>f14</BiopaxRef>
+    <Graphics ZOrder="12288" LineThickness="1.0">
+      <Point X="317.110864341753" Y="427.80273407177" GraphRef="d3828" RelX="-1.0" RelY="0.5" />
+      <Point X="204.02062481027792" Y="521.8558957342642" ArrowHead="mim-inhibition" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction>
+    <BiopaxRef>a2c</BiopaxRef>
+    <Graphics ConnectorType="Segmented" ZOrder="12288" LineThickness="1.0">
+      <Point X="104.86743173723785" Y="464.9782350613376" />
+      <Point X="134.0" Y="389.75132100311697" GraphRef="fb891" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Anchor Position="0.6214633748409417" Shape="None" GraphId="b8e73" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction>
+    <Graphics ZOrder="12288" LineThickness="1.0">
+      <Point X="102.45310245310262" Y="418.5558060212756" GraphRef="fc3ab" RelX="1.0" RelY="-0.5" />
+      <Point X="122.97225592759813" Y="418.22746317184635" GraphRef="b8e73" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction>
+    <Graphics ZOrder="12288" LineThickness="1.0">
+      <Point X="192.6560153706967" Y="439.9680989728468" GraphRef="b8071" RelX="1.0" RelY="-0.5" />
+      <Point X="122.97225592759813" Y="418.22746317184635" GraphRef="b8e73" RelX="0.0" RelY="0.0" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction>
+    <BiopaxRef>a2c</BiopaxRef>
+    <Graphics ZOrder="12288" LineThickness="1.0">
+      <Point X="114.31552376564997" Y="684.3560269441234" GraphRef="eb473" RelX="0.0" RelY="-1.0" />
+      <Point X="97.59422958870488" Y="611.0561694290967" GraphRef="c0d8d" RelX="0.0" RelY="1.0" ArrowHead="mim-conversion" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction>
+    <Graphics ConnectorType="Curved" ZOrder="12288" LineStyle="Broken" LineThickness="1.0">
+      <Point X="159.31552376564997" Y="691.6295933075078" GraphRef="eb473" RelX="1.0" RelY="-0.5" />
+      <Point X="403.3149171270718" Y="727.6382779620731" />
+      <Point X="448.7892079761766" Y="763.6469626166383" GraphRef="c1b43" RelX="-1.0" RelY="-0.5" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id136d1678">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="c18dd" X="305.99718063756086" Y="389.13744746106664" GraphRef="fb891" RelX="1.0" RelY="0.0" />
-      <Point GraphId="f8a18" X="604.508609243301" Y="389.13744746106664" GraphRef="c964e" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Point X="305.99718063756086" Y="389.75132100311697" GraphRef="fb891" RelX="1.0" RelY="0.0" />
+      <Point X="604.508609243301" Y="389.13744746106664" GraphRef="c964e" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
       <Anchor Position="0.4" Shape="None" GraphId="f2983" />
     </Graphics>
     <Xref Database="Rhea" ID="45142" />
@@ -292,184 +359,185 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
   <Interaction GraphId="id16e3906c">
     <BiopaxRef>d9e</BiopaxRef>
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="c339d" X="416.9949738415153" Y="640.4326769023518" GraphRef="b817f" RelX="-1.0" RelY="0.5" ArrowHead="mim-conversion" />
-      <Point GraphId="c6446" X="176.99929515939021" Y="407.7987044459428" GraphRef="fb891" RelX="-0.5" RelY="1.0" />
+      <Point X="416.9949738415153" Y="640.4326769023518" GraphRef="b817f" RelX="-1.0" RelY="0.5" ArrowHead="mim-conversion" />
+      <Point X="176.99929515939021" Y="408.41257798799313" GraphRef="fb891" RelX="-0.5" RelY="1.0" />
       <Anchor Position="0.34073652305745" Shape="None" GraphId="e7e6a" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id1a97c2e1">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="e7e90" X="454.67320899253275" Y="573.0462329581688" GraphRef="d28e1" RelX="-0.5" RelY="1.0" />
-      <Point GraphId="d023d" X="370.9283607008336" Y="523.8034107438635" GraphRef="fc869" RelX="0.0" RelY="0.0" />
+      <Point X="452.26820658753024" Y="573.0462329581688" GraphRef="d28e1" RelX="-0.5" RelY="1.0" />
+      <Point X="370.9283607008336" Y="524.0843363836856" GraphRef="fc869" RelX="0.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id226f1d6d">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="e8970" X="278.54205431203184" Y="561.5663210411649" GraphRef="cc54d" RelX="1.0" RelY="0.0" />
-      <Point GraphId="e5bde" X="335.219680738555" Y="561.1657859825124" GraphRef="e7e6a" RelX="0.0" RelY="0.0" />
+      <Point X="278.54205431203184" Y="561.5663210411649" GraphRef="cc54d" RelX="1.0" RelY="0.0" />
+      <Point X="335.219680738555" Y="561.3749551188275" GraphRef="e7e6a" RelX="0.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id4c639557">
     <Graphics ConnectorType="Curved" ZOrder="12288" LineStyle="Broken" LineThickness="1.0" Color="009999">
-      <Point GraphId="d0654" X="448.7892079761766" Y="769.8969626166383" GraphRef="c1b43" RelX="-1.0" RelY="0.0" />
-      <Point GraphId="d86e3" X="385.00851984894706" Y="817.6985499182257" />
-      <Point GraphId="cd1d7" X="480.51781562805627" Y="865.500137219813" GraphRef="a8671" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Point X="448.7892079761766" Y="769.8969626166383" GraphRef="c1b43" RelX="-1.0" RelY="0.0" />
+      <Point X="385.00851984894706" Y="817.6985499182257" />
+      <Point X="480.51781562805627" Y="865.500137219813" GraphRef="a8671" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
       <Anchor Position="0.4" Shape="None" GraphId="d1f1b" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id58e523d0">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="c81be" X="424.7582986171592" Y="312.0670549272991" GraphRef="c9e9c" RelX="0.0" RelY="1.0" />
-      <Point GraphId="d7e66" X="425.4017520798569" Y="389.13744746106664" GraphRef="f2983" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="424.7582986171592" Y="312.0670549272991" GraphRef="c9e9c" RelX="0.0" RelY="1.0" />
+      <Point X="425.4017520798569" Y="389.5057715862968" GraphRef="f2983" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id5ec7839e">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="f6814" X="491.5998438343944" Y="564.5517988125905" GraphRef="d28e1" RelX="1.0" RelY="0.0" />
-      <Point GraphId="e8e62" X="588.9567014777498" Y="531.077894707893" GraphRef="fce24" RelX="0.0" RelY="0.0" />
+      <Point X="489.1948414293919" Y="564.5517988125905" GraphRef="d28e1" RelX="1.0" RelY="0.0" />
+      <Point X="594.6982252738205" Y="523.8552729119554" GraphRef="fce24" RelX="0.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id62634f8a">
     <BiopaxRef>d9e</BiopaxRef>
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="e4a46" X="348.10583458586683" Y="635.7354606628214" GraphRef="b746e" RelX="0.0" RelY="-1.0" />
-      <Point GraphId="bc6ba" X="381.94905582543765" Y="565.6081787881053" GraphRef="e3cd2" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="348.10583458586683" Y="635.7354606628214" GraphRef="b746e" RelX="0.0" RelY="-1.0" />
+      <Point X="381.94905582543765" Y="565.7691195560401" GraphRef="e3cd2" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id77d30e7b">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="bcf9f" X="425.4017520798569" Y="389.13744746106664" GraphRef="f2983" RelX="0.0" RelY="0.0" />
-      <Point GraphId="d2178" X="506.92322221205103" Y="292.20649126141893" GraphRef="db2f9" RelX="-1.0" RelY="0.5" ArrowHead="mim-conversion" />
+      <Point X="425.4017520798569" Y="389.5057715862968" GraphRef="f2983" RelX="0.0" RelY="0.0" />
+      <Point X="506.92322221205103" Y="292.20649126141893" GraphRef="db2f9" RelX="-1.0" RelY="0.5" ArrowHead="mim-conversion" />
     </Graphics>
     <Xref Database="Rhea" ID="45142" />
   </Interaction>
   <Interaction GraphId="id7f177b7f">
     <Graphics ZOrder="12288" LineStyle="Broken" LineThickness="1.0" Color="999999">
-      <Point GraphId="c0599" X="516.4847103251341" Y="713.6545736097723" GraphRef="dd705" RelX="-0.5" RelY="1.0" />
-      <Point GraphId="ef26c" X="493.7892079761766" Y="757.3969626166383" GraphRef="c1b43" RelX="0.0" RelY="-1.0" />
+      <Point X="516.4847103251341" Y="713.6545736097723" GraphRef="dd705" RelX="-0.5" RelY="1.0" />
+      <Point X="493.7892079761766" Y="757.3969626166383" GraphRef="c1b43" RelX="0.0" RelY="-1.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id82e38e2c">
     <Graphics ZOrder="12288" LineStyle="Broken" LineThickness="1.0">
-      <Point GraphId="a78d7" X="253.1180777038447" Y="574.0663210411649" GraphRef="cc54d" RelX="0.0" RelY="1.0" />
-      <Point GraphId="cccb3" X="209.05263175485157" Y="626.0294369149948" GraphRef="d161d" RelX="0.0" RelY="-1.0" ArrowHead="Arrow" />
+      <Point X="253.1180777038447" Y="574.0663210411649" GraphRef="cc54d" RelX="0.0" RelY="1.0" />
+      <Point X="209.05263175485157" Y="626.0294369149948" GraphRef="d161d" RelX="0.0" RelY="-1.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id8bb39ad0">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="d91ba" X="370.9283607008336" Y="523.8034107438635" GraphRef="fc869" RelX="0.0" RelY="0.0" />
-      <Point GraphId="ddfaf" X="442.3643307119121" Y="524.838899187755" GraphRef="c609e" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Point X="370.9283607008336" Y="524.0843363836856" GraphRef="fc869" RelX="0.0" RelY="0.0" />
+      <Point X="439.9593283069097" Y="524.5016959494498" GraphRef="c609e" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id910271fd">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="e6f1b" X="686.9557971589638" Y="407.7987044459428" GraphRef="c964e" RelX="0.0" RelY="1.0" />
-      <Point GraphId="e4bda" X="506.9949738415153" Y="634.1826769023518" GraphRef="b817f" RelX="1.0" RelY="0.0" ArrowHead="mim-conversion" />
-      <Anchor Position="0.5445579425269961" Shape="None" GraphId="fce24" />
+      <Point X="686.9557971589638" Y="407.7987044459428" GraphRef="c964e" RelX="0.0" RelY="1.0" />
+      <Point X="506.9949738415153" Y="634.1826769023518" GraphRef="b817f" RelX="1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Anchor Position="0.5126536441901144" Shape="None" GraphId="fce24" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id9d2540ae">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="bd055" X="557.0218526781556" Y="450.08281387533026" GraphRef="d3828" RelX="0.0" RelY="1.0" />
-      <Point GraphId="e9f0a" X="497.0986460348162" Y="484.3971525342086" GraphRef="b5c12" RelX="1.0" RelY="-0.5" ArrowHead="mim-inhibition" />
+      <Point X="362.110864341753" Y="434.05273407177" GraphRef="d3828" RelX="0.0" RelY="1.0" />
+      <Point X="434.46052610648763" Y="472.37214050919664" GraphRef="b5c12" RelX="-1.0" RelY="-0.5" ArrowHead="mim-inhibition" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idb963a51d">
+    <BiopaxRef>f14</BiopaxRef>
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="e5fde" X="89.0" Y="499.5" GraphRef="c0d8d" RelX="0.0" RelY="-1.0" />
-      <Point GraphId="e3ab5" X="134.0" Y="389.13744746106664" GraphRef="fb891" RelX="-1.0" RelY="0.0" ArrowHead="mim-conversion" />
-      <Anchor Position="0.6199508145521483" Shape="None" GraphId="ad691" />
+      <Point X="97.59422958870488" Y="586.0561694290967" GraphRef="c0d8d" RelX="0.0" RelY="-1.0" />
+      <Point X="123.4979132929881" Y="490.8019459533508" GraphRef="d962f" RelX="0.0" RelY="1.0" ArrowHead="mim-conversion" />
+      <Anchor Position="0.6344461888865437" Shape="None" GraphId="ad691" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idd9777a5c">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="f29cc" X="588.9567014777498" Y="531.077894707893" GraphRef="fce24" RelX="0.0" RelY="0.0" />
-      <Point GraphId="a9cd3" X="491.5998438343943" Y="524.838899187755" GraphRef="c609e" RelX="1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Point X="594.6982252738205" Y="523.8552729119554" GraphRef="fce24" RelX="0.0" RelY="0.0" />
+      <Point X="489.1948414293919" Y="524.5016959494498" GraphRef="c609e" RelX="1.0" RelY="0.0" ArrowHead="mim-conversion" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="ided4bc3d3">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="ed0e0" X="88.77735218859331" Y="426.1927829500173" GraphRef="cce0d" RelX="1.0" RelY="0.0" />
-      <Point GraphId="da1ad" X="116.89778665484667" Y="431.080645657434" GraphRef="ad691" RelX="0.0" RelY="0.0" />
+      <Point X="84.48023739424123" Y="536.0761469770275" GraphRef="cce0d" RelX="1.0" RelY="0.0" />
+      <Point X="114.02872299300984" Y="525.6224903695626" GraphRef="ad691" RelX="0.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idef5143ba">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="c40b1" X="461.9949738415153" Y="621.6826769023518" GraphRef="b817f" RelX="0.0" RelY="-1.0" />
-      <Point GraphId="d9586" X="262.99788547817064" Y="407.7987044459428" GraphRef="fb891" RelX="0.5" RelY="1.0" ArrowHead="mim-conversion" />
+      <Point X="461.9949738415153" Y="621.6826769023518" GraphRef="b817f" RelX="0.0" RelY="-1.0" />
+      <Point X="262.99788547817064" Y="408.41257798799313" GraphRef="fb891" RelX="0.5" RelY="1.0" ArrowHead="mim-conversion" />
       <Anchor Position="0.4576278672701234" Shape="None" GraphId="fc869" />
     </Graphics>
     <Xref Database="Rhea" ID="57746" />
   </Interaction>
   <Interaction GraphId="idf4fa312a">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="f43eb" X="369.8502293859477" Y="771.6082970584365" GraphRef="a498c" RelX="0.0" RelY="1.0" />
-      <Point GraphId="e43b4" X="385.45963152517595" Y="811.0474291049912" GraphRef="d1f1b" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="369.8502293859477" Y="771.6082970584365" GraphRef="a498c" RelX="0.0" RelY="1.0" />
+      <Point X="385.45963152517595" Y="811.0474291049912" GraphRef="d1f1b" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idf5ba4b4a">
     <Graphics ZOrder="12288" LineStyle="Broken" LineThickness="1.0">
-      <Point GraphId="e7ccb" X="436.86552851149" Y="484.3971525342086" GraphRef="b5c12" RelX="-1.0" RelY="-0.5" />
-      <Point GraphId="ee47f" X="405.37582421750034" Y="477.8810769955949" GraphRef="d63fe" RelX="0.5" RelY="1.0" />
+      <Point X="494.69364362981383" Y="484.87214050919664" GraphRef="b5c12" RelX="1.0" RelY="0.5" />
+      <Point X="524.4423225339988" Y="478.0330731475911" GraphRef="d63fe" RelX="-0.5" RelY="1.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idffd0ae9">
     <Graphics ZOrder="12288" LineThickness="1.0">
-      <Point GraphId="c1aa5" X="116.89778665484667" Y="431.080645657434" GraphRef="ad691" RelX="0.0" RelY="0.0" />
-      <Point GraphId="ecfe2" X="100.8577793535207" Y="383.9520062929125" GraphRef="d47ab" RelX="1.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Point X="114.02872299300984" Y="525.6224903695626" GraphRef="ad691" RelX="0.0" RelY="0.0" />
+      <Point X="86.73868788636233" Y="509.18220887118093" GraphRef="d47ab" RelX="1.0" RelY="0.0" ArrowHead="mim-conversion" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="fc9ff">
     <Graphics ZOrder="32793" LineStyle="Broken" LineThickness="1.0" Color="999999">
-      <Point GraphId="a1c99" X="561.4847103251341" Y="713.6545736097723" GraphRef="dd705" RelX="0.5" RelY="1.0" />
-      <Point GraphId="cfad2" X="583.7892079761772" Y="757.3969626166383" GraphRef="a2f65" RelX="0.0" RelY="-1.0" />
+      <Point X="561.4847103251341" Y="713.6545736097723" GraphRef="dd705" RelX="0.5" RelY="1.0" />
+      <Point X="583.7892079761772" Y="757.3969626166383" GraphRef="a2f65" RelX="0.0" RelY="-1.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="b932d">
     <Graphics ZOrder="32794" LineStyle="Broken" LineThickness="1.0" Color="999999">
-      <Point GraphId="e165f" X="583.7892079761772" Y="782.3969626166383" GraphRef="a2f65" RelX="0.0" RelY="1.0" />
-      <Point GraphId="dce0c" X="539.6631858501557" Y="853.000137219813" GraphRef="a8671" RelX="0.0" RelY="-1.0" />
+      <Point X="583.7892079761772" Y="782.3969626166383" GraphRef="a2f65" RelX="0.0" RelY="1.0" />
+      <Point X="539.6631858501557" Y="853.000137219813" GraphRef="a8671" RelX="0.0" RelY="-1.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="b6b59">
     <Graphics ZOrder="32795" LineStyle="Broken" LineThickness="1.0" Color="999999">
-      <Point GraphId="ca1d5" X="606.2892079761772" Y="782.3969626166383" GraphRef="a2f65" RelX="0.5" RelY="1.0" />
-      <Point GraphId="c8273" X="657.9539262943501" Y="853.000137219813" GraphRef="f4cf3" RelX="0.0" RelY="-1.0" />
+      <Point X="606.2892079761772" Y="782.3969626166383" GraphRef="a2f65" RelX="0.5" RelY="1.0" />
+      <Point X="657.9539262943501" Y="853.000137219813" GraphRef="f4cf3" RelX="0.0" RelY="-1.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="d7c03">
     <Graphics ZOrder="32800" LineThickness="1.0">
-      <Point GraphId="f5249" X="364.021183085988" Y="847.8258145363407" GraphRef="ef4d2" RelX="0.0" RelY="-1.0" />
-      <Point GraphId="fe9ad" X="385.45963152517595" Y="811.0474291049912" GraphRef="d1f1b" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
+      <Point X="364.021183085988" Y="847.8258145363407" GraphRef="ef4d2" RelX="0.0" RelY="-1.0" />
+      <Point X="385.45963152517595" Y="811.0474291049912" GraphRef="d1f1b" RelX="0.0" RelY="0.0" ArrowHead="mim-catalysis" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="ddb05">
     <BiopaxRef>d9e</BiopaxRef>
     <Graphics ZOrder="32806" LineThickness="1.0">
-      <Point GraphId="d5913" X="219.99859031878043" Y="407.7987044459428" GraphRef="fb891" RelX="0.0" RelY="1.0" ArrowHead="mim-conversion" />
-      <Point GraphId="ba6d8" X="439.4949738415153" Y="621.6826769023518" GraphRef="b817f" RelX="-0.5" RelY="-1.0" />
+      <Point X="219.99859031878043" Y="408.41257798799313" GraphRef="fb891" RelX="0.0" RelY="1.0" ArrowHead="mim-conversion" />
+      <Point X="439.4949738415153" Y="621.6826769023518" GraphRef="b817f" RelX="-0.5" RelY="-1.0" />
       <Anchor Position="0.4" Shape="None" GraphId="b1d16" />
       <Anchor Position="0.7378274890341546" Shape="None" GraphId="e3cd2" />
     </Graphics>
@@ -477,28 +545,28 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
   </Interaction>
   <Interaction GraphId="cb646">
     <Graphics ZOrder="32808" LineThickness="1.0">
-      <Point GraphId="d75d1" X="335.219680738555" Y="561.1657859825124" GraphRef="e7e6a" RelX="0.0" RelY="0.0" />
-      <Point GraphId="fc696" X="312.6017731889905" Y="589.541840602358" GraphRef="d994c" RelX="0.0" RelY="-1.0" ArrowHead="mim-conversion" />
+      <Point X="335.219680738555" Y="561.3749551188275" GraphRef="e7e6a" RelX="0.0" RelY="0.0" />
+      <Point X="312.6017731889905" Y="589.541840602358" GraphRef="d994c" RelX="0.0" RelY="-1.0" ArrowHead="mim-conversion" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id900ea925">
     <Graphics ZOrder="32810" LineThickness="1.0">
-      <Point GraphId="e91cb" X="355.6441487745509" Y="291.45649126141893" GraphRef="f5cb5" RelX="1.0" RelY="0.5" />
-      <Point GraphId="e5d43" X="425.4017520798569" Y="389.13744746106664" GraphRef="f2983" RelX="0.0" RelY="0.0" ArrowHead="mim-conversion" />
+      <Point X="355.6441487745509" Y="291.45649126141893" GraphRef="f5cb5" RelX="1.0" RelY="0.5" />
+      <Point X="425.4017520798569" Y="389.5057715862968" GraphRef="f2983" RelX="0.0" RelY="0.0" ArrowHead="mim-conversion" />
     </Graphics>
     <Xref Database="Rhea" ID="45142" />
   </Interaction>
   <GraphicalLine GraphId="c2514">
     <Graphics ConnectorType="Curved" ZOrder="12288" LineStyle="Broken" LineThickness="1.0">
-      <Point GraphId="ab70c" X="461.9949738415153" Y="646.6826769023518" GraphRef="b817f" RelX="0.0" RelY="1.0" />
-      <Point GraphId="f96f2" X="448.7892079761766" Y="763.6469626166383" GraphRef="c1b43" RelX="-1.0" RelY="-0.5" />
+      <Point X="461.9949738415153" Y="646.6826769023518" GraphRef="b817f" RelX="0.0" RelY="1.0" />
+      <Point X="493.98471032513413" Y="685.662688132458" GraphRef="dd705" RelX="-1.0" RelY="-0.5" />
     </Graphics>
   </GraphicalLine>
   <GraphicalLine GraphId="aec13">
     <Graphics ZOrder="32804" LineStyle="Broken" LineThickness="1.0" Color="009999">
-      <Point GraphId="e6f41" X="149.47554611391033" Y="853.173941580205" />
-      <Point GraphId="e18a1" X="184.60691968125417" Y="853.173941580205" ArrowHead="Arrow" />
+      <Point X="149.47554611391033" Y="853.173941580205" />
+      <Point X="184.60691968125417" Y="853.173941580205" ArrowHead="Arrow" />
     </Graphics>
   </GraphicalLine>
   <Label TextLabel="Vitamin K-dependent proteins&#xA;inactive form:" GraphId="af5f2" GroupRef="f5cb5">
@@ -520,7 +588,7 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
     <Graphics CenterX="252.0790160095732" CenterY="851.1143149078822" Width="125.40715561960315" Height="25.0" ZOrder="32803" FillColor="ffffff" FontSize="12" Valign="Middle" Color="404040" />
   </Label>
   <Label TextLabel="Synthetic Vitamin K:" GraphId="ff4d9">
-    <Graphics CenterX="96.62198479219651" CenterY="486.19050150629187" Width="138.75603041560697" Height="25.0" ZOrder="32809" FillColor="ffffff" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="95.59620476089181" CenterY="566.0126642013821" Width="138.75603041560697" Height="25.0" ZOrder="32809" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
   <Shape TextLabel="   Hepatocyte" GraphId="cf21f">
     <Attribute Key="org.pathvisio.CellularComponentProperty" Value="Cell" />
@@ -530,90 +598,16 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
   <Shape GraphId="c04e6">
     <Graphics CenterX="229.3391498468605" CenterY="840.0071811052562" Width="181.26346015793249" Height="71.70284758392737" ZOrder="32801" FontSize="12" Valign="Middle" ShapeType="Rectangle" Rotation="0.0" />
   </Shape>
-  <Group GroupId="f5cb5" GraphId="f5cb5" Style="Group" />
-  <Group GroupId="db2f9" GraphId="db2f9" Style="Group" />
   <Group GroupId="d63fe" GraphId="d63fe" Style="Complex" />
+  <Group GroupId="db2f9" GraphId="db2f9" Style="Group" />
+  <Group GroupId="f5cb5" GraphId="f5cb5" Style="Group" />
   <InfoBox CenterX="0.0" CenterY="0.0" />
   <Biopax>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">classic metabolic pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0000002</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferroptosis pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0002626</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K metabolic pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0001016</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lipid metabolic pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0000010</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K deficiency bleeding</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOID:11249</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human Disease Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
     <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
       <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hemostasis pathway</bp:TERM>
       <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0000475</bp:ID>
       <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
     </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin and vitamin metabolites signaling pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0001012</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hepatocyte</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000182</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K cycle pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0002592</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
-      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K antagonist drug pathway</bp:TERM>
-      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0002325</bp:ID>
-      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
-    </bp:openControlledVocabulary>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="bbe">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">27437760</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Effect of vitamin K in bone metabolism and vascular calcification: A review of mechanisms of action and evidences.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crit Rev Food Sci Nutr</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Villa JKD</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diaz MAN</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pizziolo VR</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Martino HSD</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="fca">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25079019</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vitamin K and cardiovascular calcification in CKD: is patient supplementation on the horizon?</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kidney Int</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gallieni M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fusaro M</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a8c">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">35922487</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Long-sought mediator of vitamin K recycling discovered</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nature</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2022</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nathan P Ward</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gina M DeNicola</bp:AUTHORS>
-    </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="b6b">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">35510250</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
@@ -633,15 +627,16 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wei Zhang</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xi Li</bp:AUTHORS>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a88">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26904004</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genomic Analysis of the Human Gut Microbiome Suggests Novel Enzymes Involved in Quinone Biosynthesis</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Front Microbiol.</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2016</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmitry A Ravcheev</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ines Thiele</bp:AUTHORS>
-    </bp:PublicationXref>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">classic metabolic pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0000002</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K metabolic pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0001016</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d9e">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">35922516</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
@@ -676,5 +671,107 @@ The influence of FSP1 on this process, as well as its potential to eliminate lip
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Derek A Pratt</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Marcus Conrad</bp:AUTHORS>
     </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="bbe">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">27437760</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Effect of vitamin K in bone metabolism and vascular calcification: A review of mechanisms of action and evidences.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crit Rev Food Sci Nutr</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Villa JKD</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diaz MAN</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pizziolo VR</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Martino HSD</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hepatocyte</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CL:0000182</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ferroptosis pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0002626</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K cycle pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0002592</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin and vitamin metabolites signaling pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0001012</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a8c">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">35922487</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Long-sought mediator of vitamin K recycling discovered</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nature</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2022</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nathan P Ward</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gina M DeNicola</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lipid metabolic pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0000010</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K antagonist drug pathway</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PW:0002325</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pathway Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="fca">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25079019</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vitamin K and cardiovascular calcification in CKD: is patient supplementation on the horizon?</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kidney Int</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gallieni M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fusaro M</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:openControlledVocabulary xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+      <bp:TERM xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vitamin K deficiency bleeding</bp:TERM>
+      <bp:ID xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOID:11249</bp:ID>
+      <bp:Ontology xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human Disease Ontology</bp:Ontology>
+    </bp:openControlledVocabulary>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a88">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26904004</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genomic Analysis of the Human Gut Microbiome Suggests Novel Enzymes Involved in Quinone Biosynthesis</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Front Microbiol.</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2016</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dmitry A Ravcheev</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ines Thiele</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="f14">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">24489112</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Recent trends in the metabolism and cell biology of vitamin K with special reference to vitamin K cycling and MK-4 biosynthesis.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Lipid Res</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shearer MJ</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Newman P</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a2c">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">24085302</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Menadione (vitamin K3) is a catabolic product of oral phylloquinone (vitamin K1) in the intestine and a circulating precursor of tissue menaquinone-4 (vitamin K2) in rats.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Biol Chem</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2013</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hirota Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tsugawa N</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nakagawa K</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Suhara Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tanaka K</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uchino Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Takeuchi A</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sawada N</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kamao M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wada A</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Okitsu T</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Okano T</bp:AUTHORS>
+    </bp:PublicationXref>
   </Biopax>
 </Pathway>
+


### PR DESCRIPTION
This is an attempt at adding the recent-ish evidence about circulating menadione ("K3") into the chart.

* Swap the location of warfarin and VKOR isoform boxes, because warfarin also inhibits NQO1
* Split the K3 -> KH2 step into K3 -> menadiol via (possibly) NQO1 and menadiol -> KH2 via UBIAD1
* Add K1 -> menadione
* Swap the "K1" in the triangular cycle with a generic "K"