### PR TITLE
Fix two bp:DB references

### DIFF
--- a/pathways/WP4549/WP4549.gpml
+++ b/pathways/WP4549/WP4549.gpml
@@ -3639,7 +3639,7 @@ protein (CREB) at Ser133</Comment>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="ee2">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Q9Y566</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uniprot-TrEMBL	</bp:DB>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uniprot-TrEMBL</bp:DB>
       <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UniProtKB - Q9Y566 (SHAN1_HUMAN)</bp:TITLE>
       <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.uniprot.org/uniprot/Q9Y566</bp:SOURCE>
       <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></bp:YEAR>

--- a/pathways/WP5044/WP5044.gpml
+++ b/pathways/WP5044/WP5044.gpml
@@ -1126,7 +1126,7 @@ Kyn is further converted into 3-hydroxykynurenine (3HK) by kynurenine monooxygen
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="b5e">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">map00380</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KEGG Pathways</bp:DB>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KEGG Pathway</bp:DB>
       <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tryptophan metabolism, map00380</bp:TITLE>
       <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.genome.jp/dbget-bin/www_bget?pathway:map00380</bp:SOURCE>
       <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></bp:YEAR>


### PR DESCRIPTION
- Remove tab character from end of one `bp:DB` leading to an [invalid TSV](https://github.com/larsgw/wikipathways-database/blob/684cd1fe7fafd6e3c250d0ce2cd1adea19171a53/pathways/WP4549/WP4549-refs.tsv)
- Change `KEGG Pathways` in `bp:DB` to `KEGG Pathway` [following BridgeDB](https://github.com/bridgedb/datasources/blob/main/datasources.tsv#L67)