### PR TITLE
Update WP5636 Mitophagy pathway

### DIFF
--- a/pathways/WP5636/WP5636.gpml
+++ b/pathways/WP5636/WP5636.gpml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Pathway xmlns="http://pathvisio.org/GPML/2013a" Name="Mitophagy" Data-Source="WikiPathways" Version="20260507000000" Author="[FloorBoereboom, Marvin M2]" Last-Modified="20260507000000" Organism="Homo sapiens">
+<Pathway xmlns="http://pathvisio.org/GPML/2013a" Name="Mitophagy" Data-Source="WikiPathways" Version="20260520000000" Author="[FloorBoereboom, Marvin M2]" Last-Modified="20260520000000" Organism="Homo sapiens">
   <Comment Source="WikiPathways-description">KEGG pathway map04137 was used as a reference pathway. Mitochondria are the organelles controlling cellular energy levels. Mitophagy refers to the selective autophagic process for mitochondria, preventing programmed cell death. Damaged mitochondria trigger PINK1-Parkin mediated mitophagy. In healthy mitochondria, PINK1 is imported via the TOM/TIM complexes and is degraded. The import through TIM fails when the mitochondria are damaged and lose membrane potential, causing PINK1 to accumulate inside the outer mitochondrial membrane. Accumulated PINK1 recruits and activates the protein Parkin, which ubiquitinates outer mitochondrial membrane proteins tagging the mitochondria for degradation. Furthermore, Parkin promotes mitochondrial fragmentation by ubiquitinating fusion factors, shifting the balance toward fission. ER stress can also recruit Parkin. There are two ways mitochondria are recognized by autophagy receptors including LC3 on the forming autophagosome: SLR (ubiquitin-dependent) pathway: recognition of Parkin generated ubiquitin chains; Non-SLR (ubiquitin-independent) pathway: direct mitochondrial stress signals including hypoxia- or Gq-related signaling. Finally, the autophagosome fuses with lysosome for degradation of the mitochondria and the transport is regulated by endosomal Rab cycles. Rab GTPases cycle between active (GTP-bound) and inactive (GDP-bound) states to control maturation of the vesicle and fusion along microtubules. Therefore, ensuring efficient transport of the autophagosome to the lysosome and clearance of damaged mitochondria.</Comment>
   <BiopaxRef>c41</BiopaxRef>
   <BiopaxRef>e08</BiopaxRef>
@@ -10,7 +10,7 @@
   <BiopaxRef>f1a</BiopaxRef>
   <BiopaxRef>a5c</BiopaxRef>
   <BiopaxRef>c7c</BiopaxRef>
-  <Graphics BoardWidth="1715.5263639964792" BoardHeight="1733.6745283018872" />
+  <Graphics BoardWidth="1715.5263639964792" BoardHeight="1769.1625156406217" />
   <DataNode TextLabel="EIF2AK3" GraphId="c3f1e" Type="GeneProduct">
     <Graphics CenterX="81.12849286923438" CenterY="1088.9191127592653" Width="90.0" Height="25.0" ZOrder="32768" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000172071" />
@@ -52,23 +52,19 @@
     <Xref Database="Ensembl" ID="ENSG00000121749" />
   </DataNode>
   <DataNode TextLabel="FUNDC1" GraphId="f7206" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="749.9846460815743" Width="90.0" Height="25.0" ZOrder="32790" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="753.2953200243988" Width="90.0" Height="25.0" ZOrder="32790" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000069509" />
   </DataNode>
   <DataNode TextLabel="BNIP3" GraphId="b3f3e" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658135" CenterY="784.4865653213778" Width="92.01646991748169" Height="25.0" ZOrder="32793" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.9678652467567" CenterY="787.7972392642024" Width="92.01646991748169" Height="25.0" ZOrder="32793" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000176171" />
   </DataNode>
   <DataNode TextLabel="ATF4" GraphId="ab269" Type="GeneProduct">
     <Graphics CenterX="376.0" CenterY="1088.0" Width="90.0" Height="25.0" ZOrder="32796" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000128272" />
   </DataNode>
-  <DataNode TextLabel="MON1 " GraphId="b7728" Type="GeneProduct" GroupRef="ebb02">
-    <Graphics CenterX="1152.1890222666302" CenterY="1388.2235210202996" Width="90.0" Height="25.0" ZOrder="32798" FontSize="12" Valign="Middle" />
-    <Xref Database="" ID="" />
-  </DataNode>
   <DataNode TextLabel="MITF" GraphId="ebcde" Type="GeneProduct" GroupRef="fa734">
-    <Graphics CenterX="421.0" CenterY="1596.0" Width="90.0" Height="25.0" ZOrder="32800" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="418.31980871875" CenterY="1593.3198087187493" Width="90.0" Height="25.0" ZOrder="32800" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000187098" />
   </DataNode>
   <DataNode TextLabel="JUN" GraphId="de19e" Type="GeneProduct">
@@ -151,12 +147,8 @@
     <Graphics CenterX="631.0" CenterY="137.0" Width="90.0" Height="25.0" ZOrder="32841" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000159461" />
   </DataNode>
-  <DataNode TextLabel="Ubiquitin E3 ligases" GraphId="b6de7" Type="Pathway">
-    <Graphics CenterX="626.0" CenterY="75.0" Width="136.0" Height="25.0" ZOrder="32843" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
   <DataNode TextLabel="CALCOCO2" GraphId="cabc8" Type="GeneProduct" GroupRef="eca25">
-    <Graphics CenterX="1128.9971211402953" CenterY="437.00767695921274" Width="90.0" Height="25.0" ZOrder="32845" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1128.3196322697447" CenterY="434.97521034756056" Width="90.0" Height="25.0" ZOrder="32845" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000136436" />
   </DataNode>
   <DataNode TextLabel="TOMM7" GraphId="b9ffd" Type="GeneProduct" GroupRef="b5196">
@@ -164,7 +156,7 @@
     <Xref Database="Ensembl" ID="ENSG00000196683" />
   </DataNode>
   <DataNode TextLabel="Autophagy" GraphId="d4bce" Type="Pathway">
-    <Graphics CenterX="438.6247942204935" CenterY="164.01408450704218" Width="90.0" Height="25.0" ZOrder="32850" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
+    <Graphics CenterX="438.6247942204935" CenterY="159.9937975851673" Width="90.0" Height="25.0" ZOrder="32850" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
     <Xref Database="WikiPathways" ID="WP4923" />
   </DataNode>
   <DataNode TextLabel="USP30" GraphId="c4bec" Type="GeneProduct" GroupRef="c0fd0">
@@ -172,7 +164,7 @@
     <Xref Database="Ensembl" ID="ENSG00000135093" />
   </DataNode>
   <DataNode TextLabel="SQSTM1" GraphId="e4173" Type="GeneProduct" GroupRef="eca25">
-    <Graphics CenterX="1128.9971211402953" CenterY="404.0" Width="90.0" Height="25.0" ZOrder="32854" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1128.3196322697447" CenterY="401.9675333883478" Width="90.0" Height="25.0" ZOrder="32854" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000161011" />
   </DataNode>
   <DataNode TextLabel="PINK1" GraphId="e9c9a" Type="GeneProduct">
@@ -216,7 +208,7 @@
     <Xref Database="Ensembl" ID="ENSG00000105701" />
   </DataNode>
   <DataNode TextLabel="TAX1BP1" GraphId="ae313" Type="GeneProduct" GroupRef="eca25">
-    <Graphics CenterX="1128.9971211402953" CenterY="379.0" Width="90.0" Height="25.0" ZOrder="32878" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1128.3196322697447" CenterY="376.9675333883478" Width="90.0" Height="25.0" ZOrder="32878" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000106052" />
   </DataNode>
   <DataNode TextLabel="TOMM70" GraphId="db756" Type="GeneProduct" GroupRef="e8374">
@@ -228,76 +220,52 @@
     <Xref Database="Ensembl" ID="ENSG00000126581" />
   </DataNode>
   <DataNode TextLabel="OPTN" GraphId="f9e76" Type="GeneProduct" GroupRef="eca25">
-    <Graphics CenterX="1128.9971211402953" CenterY="471.0163135383273" Width="90.0" Height="25.0" ZOrder="32885" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1128.3196322697447" CenterY="468.98384692667514" Width="90.0" Height="25.0" ZOrder="32885" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000123240" />
   </DataNode>
   <DataNode TextLabel="NBR1" GraphId="c5f20" Type="GeneProduct" GroupRef="eca25">
-    <Graphics CenterX="1128.9971211402953" CenterY="505.02495011744185" Width="90.0" Height="25.0" ZOrder="32888" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1128.3196322697447" CenterY="502.99248350578966" Width="90.0" Height="25.0" ZOrder="32888" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000188554" />
   </DataNode>
-  <DataNode TextLabel="Sequestome-like (SLR)&#xA;receptor&#xA;" GraphId="f479b" Type="Pathway">
-    <Graphics CenterX="1128.9971211402953" CenterY="338.0" Width="152.0" Height="25.0" ZOrder="32894" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
   <DataNode TextLabel="Autophagy" GraphId="fdd80" Type="Pathway">
-    <Graphics CenterX="1385.2044320717985" CenterY="395.14465800603926" Width="90.0" Height="25.0" ZOrder="32896" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
+    <Graphics CenterX="1385.2044320717985" CenterY="391.12437108416424" Width="90.0" Height="25.0" ZOrder="32896" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
     <Xref Database="WikiPathways" ID="WP4923" />
-  </DataNode>
-  <DataNode TextLabel="Misfolding proteins&#xA;mtDNA mutation&#xA;Depolarization" GraphId="fc1bc" Type="Pathway">
-    <Graphics CenterX="56.8862750051441" CenterY="205.94718309859178" Width="136.11714268828118" Height="46.5" ZOrder="32898" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
   </DataNode>
   <DataNode TextLabel="Apoptosis" GraphId="e0d25" Type="Pathway">
     <Graphics CenterX="649.25352112676" CenterY="571.2559364406345" Width="90.0" Height="25.0" ZOrder="32900" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
     <Xref Database="WikiPathways" ID="WP254" />
   </DataNode>
   <DataNode TextLabel="BNIP3L" GraphId="ddc71" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="816.493282660689" Width="90.0" Height="25.0" ZOrder="32902" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="819.8039566035136" Width="90.0" Height="25.0" ZOrder="32902" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000104765" />
   </DataNode>
   <DataNode TextLabel="BCL2L13" GraphId="ce156" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="848.5" Width="90.0" Height="25.0" ZOrder="32905" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="851.8106739428246" Width="90.0" Height="25.0" ZOrder="32905" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000099968" />
   </DataNode>
   <DataNode TextLabel="FKBP8" GraphId="cd719" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="873.5" Width="90.0" Height="25.0" ZOrder="32907" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="876.8106739428246" Width="90.0" Height="25.0" ZOrder="32907" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000105701" />
   </DataNode>
   <DataNode TextLabel="MUL1" GraphId="d06b4" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="898.5" Width="90.0" Height="25.0" ZOrder="32909" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="901.8106739428246" Width="90.0" Height="25.0" ZOrder="32909" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000090432" />
   </DataNode>
   <DataNode TextLabel="SAMM50" GraphId="dc9bb" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="923.5" Width="90.0" Height="25.0" ZOrder="32911" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="926.8106739428246" Width="90.0" Height="25.0" ZOrder="32911" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000100347" />
   </DataNode>
   <DataNode TextLabel="PHB2" GraphId="a0d3f" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="948.5" Width="90.0" Height="25.0" ZOrder="32913" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="951.8106739428246" Width="90.0" Height="25.0" ZOrder="32913" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000215021" />
   </DataNode>
   <DataNode TextLabel="NLRX1" GraphId="b6845" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="973.5" Width="90.0" Height="25.0" ZOrder="32915" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="976.8106739428246" Width="90.0" Height="25.0" ZOrder="32915" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000160703" />
   </DataNode>
   <DataNode TextLabel="MTX1" GraphId="f9629" Type="GeneProduct" GroupRef="d0845">
-    <Graphics CenterX="1017.8643072658136" CenterY="998.5" Width="90.0" Height="25.0" ZOrder="32917" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1018.967865246755" CenterY="1001.8106739428246" Width="90.0" Height="25.0" ZOrder="32917" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000173171" />
-  </DataNode>
-  <DataNode TextLabel="Non-SLR type&#xA;receptor&#xA;" GraphId="a5af7" Type="Pathway">
-    <Graphics CenterX="1017.8643072658139" CenterY="707.9875249412797" Width="152.0" Height="25.0" ZOrder="32919" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="Hypoxia&#xA;" GraphId="d3d2f" Type="Pathway">
-    <Graphics CenterX="46.84316741451363" CenterY="747.1524818131381" Width="112.19643550312493" Height="46.5" ZOrder="32925" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="Hypoxia&#xA;Depolarization" GraphId="e6d89" Type="Pathway">
-    <Graphics CenterX="58.77624753853978" CenterY="691.1571004226563" Width="102.34673254453122" Height="46.5" ZOrder="32927" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="Fusion factors&#xA;" GraphId="acbb8" Type="Pathway">
-    <Graphics CenterX="983.7023354348281" CenterY="567.776350971875" Width="152.0" Height="25.0" ZOrder="32931" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
   </DataNode>
   <DataNode TextLabel="EIF2S1" GraphId="f1f2f" Type="GeneProduct">
     <Graphics CenterX="233.99999999999997" CenterY="1088.0000000000002" Width="90.0" Height="25.0" ZOrder="32933" FontSize="12" Valign="Middle" />
@@ -306,14 +274,6 @@
   <DataNode TextLabel="KRAS" GraphId="bc1ee" Type="GeneProduct">
     <Graphics CenterX="233.99999999999997" CenterY="1295.0" Width="90.0" Height="25.0" ZOrder="32936" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000133703" />
-  </DataNode>
-  <DataNode TextLabel="Hypoxia&#xA;" GraphId="b5dc7" Type="Pathway">
-    <Graphics CenterX="54.54910887578123" CenterY="1353.1857991546874" Width="112.19643550312493" Height="46.5" ZOrder="32938" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="Gq signaling&#xA;" GraphId="d791c" Type="Pathway">
-    <Graphics CenterX="54.549108875781236" CenterY="1459.1857991546874" Width="112.19643550312493" Height="46.5" ZOrder="32940" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
   </DataNode>
   <DataNode TextLabel="NFkB" GraphId="af689" Type="GeneProduct">
     <Graphics CenterX="509.0940018774759" CenterY="1268.0" Width="90.0" Height="25.0" ZOrder="32942" FontSize="12" Valign="Middle" />
@@ -343,14 +303,6 @@
     <Graphics CenterX="421.0" CenterY="1457.0" Width="90.0" Height="25.0" ZOrder="32958" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="" />
   </DataNode>
-  <DataNode TextLabel="In cardiac cells" GraphId="fdede" Type="Pathway">
-    <Graphics CenterX="421.0" CenterY="1405.1857991546874" Width="112.19643550312493" Height="46.5" ZOrder="32960" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="In tumor cells&#xA;" GraphId="d5ab9" Type="Pathway">
-    <Graphics CenterX="421.0" CenterY="1515.1857991546874" Width="112.19643550312493" Height="46.5" ZOrder="32962" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
   <DataNode TextLabel="CITED2" GraphId="bd972" Type="GeneProduct">
     <Graphics CenterX="421.0" CenterY="1542.0" Width="90.0" Height="25.0" ZOrder="32964" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000164442" />
@@ -359,24 +311,16 @@
     <Graphics CenterX="234.0" CenterY="1542.0" Width="90.0" Height="25.0" ZOrder="32972" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000118689" />
   </DataNode>
-  <DataNode TextLabel="Parkin" GraphId="f8807" Type="GeneProduct">
-    <Graphics CenterX="234.0" CenterY="1624.0" Width="90.0" Height="25.0" ZOrder="32976" FontSize="12" Valign="Middle" />
-    <Xref Database="" ID="" />
-  </DataNode>
   <DataNode TextLabel="TFEB" GraphId="b70fa" Type="GeneProduct" GroupRef="fa734">
-    <Graphics CenterX="421.0" CenterY="1621.0" Width="90.0" Height="25.0" ZOrder="32978" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="418.31980871875" CenterY="1618.3198087187493" Width="90.0" Height="25.0" ZOrder="32978" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000112561" />
   </DataNode>
   <DataNode TextLabel="TFE3" GraphId="e0614" Type="GeneProduct" GroupRef="fa734">
-    <Graphics CenterX="421.0" CenterY="1646.0" Width="90.0" Height="25.0" ZOrder="32980" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="418.31980871875" CenterY="1643.3198087187493" Width="90.0" Height="25.0" ZOrder="32980" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000068323" />
   </DataNode>
-  <DataNode TextLabel="Lysosome biogenesis" GraphId="e810a" Type="Pathway" GroupRef="b5b38">
-    <Graphics CenterX="661.3771748119589" CenterY="1632.5682570643344" Width="151.64475798946376" Height="25.0" ZOrder="32982" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="Autophagy" GraphId="a0623" Type="Pathway" GroupRef="b5b38">
-    <Graphics CenterX="661.3771748119636" CenterY="1607.5682570643341" Width="90.0" Height="25.0" ZOrder="32984" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
+  <DataNode TextLabel="Autophagy" GraphId="a0623" Type="Pathway" GroupRef="a6b1a">
+    <Graphics CenterX="676.1182268588387" CenterY="1604.8880657830846" Width="90.0" Height="25.0" ZOrder="32984" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
     <Xref Database="WikiPathways" ID="WP4923" />
   </DataNode>
   <DataNode TextLabel="RAB7A" GraphId="fd7ca" Type="GeneProduct" GroupRef="dce40">
@@ -411,8 +355,8 @@
     <Graphics CenterX="1301.0679161895016" CenterY="1524.4739715693986" Width="90.0" Height="25.0" ZOrder="33006" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000276600" />
   </DataNode>
-  <DataNode TextLabel="CCZ1" GraphId="d6129" Type="GeneProduct" GroupRef="ebb02">
-    <Graphics CenterX="1152.1890222666302" CenterY="1413.2235210202996" Width="90.00000000000003" Height="24.999999999999947" ZOrder="33013" FontSize="12" Valign="Middle" />
+  <DataNode TextLabel="CCZ1" GraphId="d6129" Type="GeneProduct" GroupRef="ad2de">
+    <Graphics CenterX="1154.86921354788" CenterY="1410.543329739049" Width="90.00000000000003" Height="24.999999999999947" ZOrder="33013" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000122674" />
   </DataNode>
   <DataNode TextLabel="RAB5A" GraphId="e097a" Type="GeneProduct" GroupRef="c3fe3">
@@ -426,14 +370,6 @@
   <DataNode TextLabel="RAB5C" GraphId="b4b5d" Type="GeneProduct" GroupRef="c3fe3">
     <Graphics CenterX="1301.067916189502" CenterY="1313.4394728157338" Width="90.0" Height="25.0" ZOrder="33021" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000108774" />
-  </DataNode>
-  <DataNode TextLabel="Outer membrane protein" GraphId="a331d" Type="Pathway">
-    <Graphics CenterX="869.7978928542605" CenterY="397.88443863955524" Width="154.89222552168707" Height="25.0" ZOrder="33036" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
-  </DataNode>
-  <DataNode TextLabel="Endosomal Rab cycles&#xA;" GraphId="d6e39" Type="Pathway">
-    <Graphics CenterX="956.5435525488327" CenterY="1203.814086820935" Width="152.0" Height="25.0" ZOrder="33059" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="None" />
-    <Xref Database="" ID="" />
   </DataNode>
   <DataNode TextLabel="BECN2" GraphId="edf69" Type="GeneProduct" GroupRef="b0bcc">
     <Graphics CenterX="438.6247942204935" CenterY="255.0" Width="90.0" Height="25.0" ZOrder="33060" FontSize="12" Valign="Middle" />
@@ -458,10 +394,6 @@
   <DataNode TextLabel="MAPK10" GraphId="fe93d" Type="GeneProduct" GroupRef="ac50a">
     <Graphics CenterX="233.99999999999991" CenterY="1202.0000000000002" Width="90.0" Height="25.0" ZOrder="33065" FontSize="12" Valign="Middle" />
     <Xref Database="Ensembl" ID="ENSG00000109339" />
-  </DataNode>
-  <DataNode TextLabel="" GraphId="d5ddf" Type="Pathway">
-    <Graphics CenterX="1302.1981248219504" CenterY="268.08624583735946" Width="73.00147000734023" Height="21.842263523134896" ZOrder="33066" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
-    <Xref Database="WikiPathways" ID="WP4923" />
   </DataNode>
   <State GraphRef="c6796" TextLabel="U" GraphId="c3410">
     <Graphics RelX="0.9999999999999988" RelY="0.0" Width="15.0" Height="15.0" ShapeType="Oval" />
@@ -533,14 +465,14 @@
   <Interaction GraphId="idf92804cb">
     <Graphics ZOrder="12290" LineThickness="1.0">
       <Point X="1287.0754716981128" Y="429.5" GraphRef="d762a" RelX="0.0" RelY="-1.0" />
-      <Point X="1340.2044320717985" Y="395.14465800603926" GraphRef="fdd80" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="1340.2044320717985" Y="391.12437108416424" GraphRef="fdd80" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id16f14d0a">
     <Graphics ZOrder="12292" LineStyle="Broken" LineThickness="1.0">
       <Point X="438.6247942204935" Y="205.5" GraphRef="d27e0" RelX="0.0" RelY="-1.0" />
-      <Point X="438.6247942204935" Y="176.51408450704218" GraphRef="d4bce" RelX="0.0" RelY="1.0" ArrowHead="Arrow" />
+      <Point X="438.6247942204935" Y="172.4937975851673" GraphRef="d4bce" RelX="0.0" RelY="1.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -553,7 +485,7 @@
   </Interaction>
   <Interaction GraphId="id873ac0c3">
     <Graphics ZOrder="12296" LineStyle="Broken" LineThickness="1.0">
-      <Point X="124.94484634928469" Y="205.94718309859178" GraphRef="fc1bc" RelX="1.0" RelY="0.0" />
+      <Point X="119.26851201562503" Y="203.18259680468674" GraphRef="d67ec" RelX="1.0" RelY="0.0" />
       <Point X="392.0" Y="357.0" GraphRef="e9c9a" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -570,7 +502,7 @@
   </Interaction>
   <Interaction GraphId="id1e2e4b22">
     <Graphics ZOrder="12300" LineThickness="1.0">
-      <Point X="1081.9371858827187" Y="882.25" />
+      <Point X="1076.9761002054975" Y="877.5529969836117" GraphRef="a6f1f" RelX="1.0" RelY="0.0" />
       <Point X="1242.0754716981128" Y="442.0" GraphRef="d762a" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -578,14 +510,14 @@
   <Interaction GraphId="id62115ef">
     <Graphics ZOrder="12302" LineThickness="1.0">
       <Point X="692.36672867393" Y="861.8867924528305" GraphRef="b1a08" RelX="1.0" RelY="0.0" />
-      <Point X="972.8643072658137" Y="756.2346460815743" GraphRef="f7206" RelX="-1.0" RelY="0.5" ArrowHead="Arrow" />
+      <Point X="973.9678652467551" Y="759.5453200243988" GraphRef="f7206" RelX="-1.0" RelY="0.5" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id4045b769">
     <Graphics ZOrder="12304" LineThickness="1.0">
       <Point X="928.1340621950476" Y="462.2823053760241" GraphRef="d0721" RelX="1.0" RelY="0.0" />
-      <Point X="1075.0" Y="429.0" ArrowHead="Arrow" />
+      <Point X="1071.3196322697447" Y="439.9800084470687" GraphRef="b4c9a" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -607,7 +539,7 @@
   <Interaction GraphId="id1bfe737b">
     <Graphics ZOrder="12310" LineThickness="1.0">
       <Point X="1272.567916189502" Y="1337.9394728157338" GraphRef="a7549" RelX="-0.5" RelY="1.0" />
-      <Point X="1197.1890222666302" Y="1388.2235210202996" GraphRef="b7728" RelX="1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="1199.86921354788" Y="1384.3187967656236" GraphRef="ba816" RelX="1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -632,7 +564,7 @@
   <Interaction GraphId="id2ffef138">
     <Graphics ConnectorType="Curved" ZOrder="12316" LineThickness="1.0" Color="ff3333">
       <Point X="694.25352112676" Y="689.75" GraphRef="be942" RelX="1.0" RelY="0.0" />
-      <Point X="844.0838717587375" Y="757.0454789681595" GraphRef="bca78" RelX="0.0" RelY="0.0" ArrowHead="TBar" />
+      <Point X="844.63173342849" Y="758.6890639774174" GraphRef="bca78" RelX="0.0" RelY="0.0" ArrowHead="TBar" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -652,35 +584,35 @@
   </Interaction>
   <Interaction GraphId="idfa74110e">
     <Graphics ZOrder="12322" LineStyle="Broken" LineThickness="1.0">
-      <Point X="109.94961381080539" Y="691.1571004226563" GraphRef="e6d89" RelX="1.0" RelY="0.0" />
+      <Point X="104.06116156249998" Y="688.945182499998" GraphRef="bf799" RelX="1.0" RelY="0.0" />
       <Point X="604.25352112676" Y="689.75" GraphRef="be942" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id8d391894">
     <Graphics ZOrder="12324" LineThickness="1.0">
-      <Point X="1197.1890222666302" Y="1413.2235210202996" GraphRef="d6129" RelX="1.0" RelY="0.0" />
+      <Point X="1199.86921354788" Y="1410.543329739049" GraphRef="d6129" RelX="1.0" RelY="0.0" />
       <Point X="1272.5679161895016" Y="1474.9739715693986" GraphRef="d6456" RelX="-0.5" RelY="-1.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="id4cbbaa09">
     <Graphics ZOrder="12326" LineStyle="Broken" LineThickness="1.0">
-      <Point X="279.0" Y="1624.0" GraphRef="f8807" RelX="1.0" RelY="0.0" />
-      <Point X="368.0" Y="1621.0" GraphRef="d0618" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="263.761691266629" Y="1618.1147687499974" GraphRef="cb0f4" RelX="1.0" RelY="0.0" />
+      <Point X="365.31980871875" Y="1618.3198087187493" GraphRef="d0618" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idb7c99513">
     <Graphics ZOrder="12328" LineStyle="Broken" LineThickness="1.0">
       <Point X="653.0" Y="1342.0" GraphRef="b4554" RelX="1.0" RelY="0.0" />
-      <Point X="971.8560723070727" Y="784.4865653213778" GraphRef="b3f3e" RelX="-1.0" RelY="0.0" />
+      <Point X="972.9596302880159" Y="787.7972392642024" GraphRef="b3f3e" RelX="-1.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="idc06fb6b4">
     <Graphics ConnectorType="Curved" ZOrder="12330" LineStyle="Broken" LineThickness="1.0" Color="ff3333">
-      <Point X="102.94138516607609" Y="747.1524818131381" GraphRef="d3d2f" RelX="1.0" RelY="0.0" />
+      <Point X="96.37641156249998" Y="753.0331824999969" GraphRef="d9f1c" RelX="1.0" RelY="0.0" />
       <Point X="517.3444357168411" Y="764.0067627074964" GraphRef="f4337" RelX="-1.0" RelY="0.0" ArrowHead="TBar" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -695,7 +627,7 @@
   <Interaction GraphId="id56cb9d7">
     <Graphics ZOrder="12334" LineThickness="1.0">
       <Point X="717.1190836041668" Y="764.0067627074964" GraphRef="f4337" RelX="1.0" RelY="0.0" />
-      <Point X="972.8643072658137" Y="749.9846460815743" GraphRef="f7206" RelX="-1.0" RelY="0.0" ArrowHead="TBar" />
+      <Point X="973.9678652467551" Y="753.2953200243988" GraphRef="f7206" RelX="-1.0" RelY="0.0" ArrowHead="TBar" />
       <Anchor Position="0.4964502810130529" Shape="None" GraphId="bca78" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -710,7 +642,7 @@
   <Interaction GraphId="idd96ece54">
     <Graphics ZOrder="12338" LineThickness="1.0">
       <Point X="971.2359560176267" Y="338.55688187224587" GraphRef="f2da1" RelX="1.0" RelY="0.0" />
-      <Point X="1083.9971211402953" Y="404.0" GraphRef="e4173" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="1083.3196322697447" Y="401.9675333883478" GraphRef="e4173" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -744,8 +676,8 @@
   </Interaction>
   <Interaction GraphId="idc7cff3b6">
     <Graphics ZOrder="12348" LineStyle="Broken" LineThickness="1.0">
-      <Point X="474.0" Y="1621.0" GraphRef="d0618" RelX="1.0" RelY="0.0" />
-      <Point X="577.5547958172269" Y="1620.0682570643344" GraphRef="eaead" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="471.31980871875" Y="1618.3198087187493" GraphRef="d0618" RelX="1.0" RelY="0.0" />
+      <Point X="604.0752619994637" Y="1617.3880657830846" GraphRef="c1950" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -772,7 +704,7 @@
   </Interaction>
   <Interaction GraphId="id16ff88b9">
     <Graphics ZOrder="12356" LineThickness="1.0">
-      <Point X="1189.0" Y="429.0" />
+      <Point X="1185.3196322697447" Y="439.9800084470687" GraphRef="b4c9a" RelX="1.0" RelY="0.0" />
       <Point X="1242.0754716981128" Y="442.0" GraphRef="d762a" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -789,7 +721,7 @@
   </Interaction>
   <Interaction GraphId="idb90eef66">
     <Graphics ZOrder="12360" LineThickness="1.0">
-      <Point X="1107.1890222666302" Y="1388.2235210202996" GraphRef="b7728" RelX="-1.0" RelY="0.0" />
+      <Point X="1109.86921354788" Y="1384.3187967656236" GraphRef="ba816" RelX="-1.0" RelY="0.0" />
       <Point X="1047.3579915468754" Y="1337.9394728157336" GraphRef="a1223" RelX="0.5" RelY="1.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -881,41 +813,41 @@
   <Interaction GraphId="b2b83">
     <Graphics ZOrder="32890" LineThickness="1.0">
       <Point X="971.2359560176267" Y="338.55688187224587" GraphRef="f2da1" RelX="1.0" RelY="0.0" />
-      <Point X="1083.9971211402953" Y="437.00767695921274" GraphRef="cabc8" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="1083.3196322697447" Y="434.97521034756056" GraphRef="cabc8" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="af7ef">
     <Graphics ZOrder="32892" LineThickness="1.0">
       <Point X="971.2359560176267" Y="338.55688187224587" GraphRef="f2da1" RelX="1.0" RelY="0.0" />
-      <Point X="1083.9971211402953" Y="471.0163135383273" GraphRef="f9e76" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="1083.3196322697447" Y="468.98384692667514" GraphRef="f9e76" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="a4575">
     <Graphics ZOrder="32921" LineThickness="1.0">
       <Point X="692.36672867393" Y="861.8867924528305" GraphRef="b1a08" RelX="1.0" RelY="0.0" />
-      <Point X="971.8560723070727" Y="784.4865653213778" GraphRef="b3f3e" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="972.9596302880159" Y="787.7972392642024" GraphRef="b3f3e" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="e7632">
     <Graphics ZOrder="32923" LineThickness="1.0">
       <Point X="692.36672867393" Y="861.8867924528305" GraphRef="b1a08" RelX="1.0" RelY="0.0" />
-      <Point X="972.8643072658137" Y="816.493282660689" GraphRef="ddc71" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="973.9678652467551" Y="819.8039566035136" GraphRef="ddc71" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="b0f15">
     <Graphics ZOrder="32929" LineStyle="Broken" LineThickness="1.0">
-      <Point X="102.94138516607609" Y="747.1524818131381" GraphRef="d3d2f" RelX="1.0" RelY="0.0" />
+      <Point X="96.37641156249998" Y="753.0331824999969" GraphRef="d9f1c" RelX="1.0" RelY="0.0" />
       <Point X="602.36672867393" Y="861.8867924528305" GraphRef="b1a08" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="db134">
     <Graphics ZOrder="32948" LineStyle="Broken" LineThickness="1.0">
-      <Point X="110.64732662734369" Y="1353.1857991546874" GraphRef="b5dc7" RelX="1.0" RelY="0.0" />
+      <Point X="102.43267031250001" Y="1354.1347378124967" GraphRef="ae77c" RelX="1.0" RelY="0.0" />
       <Point X="376.0" Y="1355.0" GraphRef="ac2c5" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -923,20 +855,20 @@
   <Interaction GraphId="c8602">
     <Graphics ZOrder="32954" LineStyle="Broken" LineThickness="1.0">
       <Point X="653.0" Y="1367.0" GraphRef="a03fb" RelX="1.0" RelY="0.0" />
-      <Point X="972.8643072658137" Y="816.493282660689" GraphRef="ddc71" RelX="-1.0" RelY="0.0" />
+      <Point X="973.9678652467551" Y="819.8039566035136" GraphRef="ddc71" RelX="-1.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="a8424">
     <Graphics ZOrder="32966" LineStyle="Broken" LineThickness="1.0">
-      <Point X="110.64732662734369" Y="1353.1857991546874" GraphRef="b5dc7" RelX="1.0" RelY="0.0" />
+      <Point X="102.43267031250001" Y="1354.1347378124967" GraphRef="ae77c" RelX="1.0" RelY="0.0" />
       <Point X="376.0" Y="1432.0" GraphRef="aeaf4" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="edbb5">
     <Graphics ZOrder="32968" LineStyle="Broken" LineThickness="1.0">
-      <Point X="110.6473266273437" Y="1459.1857991546874" GraphRef="d791c" RelX="1.0" RelY="0.0" />
+      <Point X="103.708951875" Y="1456.237262812497" GraphRef="f21ab" RelX="1.0" RelY="0.0" />
       <Point X="376.0" Y="1457.0" GraphRef="f7da2" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -951,7 +883,7 @@
   </Interaction>
   <Interaction GraphId="a937a">
     <Graphics ZOrder="32974" LineStyle="Broken" LineThickness="1.0">
-      <Point X="110.64732662734369" Y="1353.1857991546874" GraphRef="b5dc7" RelX="1.0" RelY="0.0" />
+      <Point X="102.43267031250001" Y="1354.1347378124967" GraphRef="ae77c" RelX="1.0" RelY="0.0" />
       <Point X="211.5" Y="1529.5" GraphRef="e1d14" RelX="-0.5" RelY="-1.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -966,7 +898,7 @@
   <Interaction GraphId="c78e9">
     <Graphics ZOrder="33011" LineThickness="1.0">
       <Point X="1047.3579915468754" Y="1474.9739715693986" GraphRef="b429a" RelX="0.5" RelY="-1.0" />
-      <Point X="1107.1890222666302" Y="1413.2235210202996" GraphRef="d6129" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+      <Point X="1109.86921354788" Y="1410.543329739049" GraphRef="d6129" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -980,28 +912,28 @@
   <Interaction GraphId="a8f7a">
     <Graphics ZOrder="33026" LineThickness="1.0" Color="ff0000">
       <Point X="1266.8231146848975" Y="138.33802816901425" />
-      <Point X="1332.8231146848973" Y="138.33802816901425" ArrowHead="TBar" />
+      <Point X="1333.6001824794753" Y="138.50470403980853" GraphRef="f764d" RelX="-1.0" RelY="0.0" ArrowHead="TBar" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="e4882">
     <Graphics ZOrder="33048" LineThickness="1.0">
       <Point X="1266.9422251687683" Y="177.15728925772396" />
-      <Point X="1332.9422251687681" Y="177.15728925772396" ArrowHead="Arrow" />
+      <Point X="1330.890925015438" Y="176.65375201066593" GraphRef="cd10d" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="ab310">
     <Graphics ZOrder="33050" LineStyle="Broken" LineThickness="1.0">
-      <Point X="1268.7081505719937" Y="204.44884591094973" />
-      <Point X="1334.7081505719934" Y="204.44884591094973" ArrowHead="Arrow" />
+      <Point X="1267.2148787953995" Y="205.19672207982376" />
+      <Point X="1332.7970267714454" Y="204.66591568699164" GraphRef="c2f64" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
   <Interaction GraphId="ffbad">
     <Graphics ZOrder="33052" LineStyle="Broken" LineThickness="1.0">
       <Point X="1268.8272610558652" Y="236.68084732224008" />
-      <Point X="1334.827261055865" Y="236.68084732224008" />
+      <Point X="1340.032569781268" Y="236.54294859713409" GraphRef="fcd8e" RelX="-1.0" RelY="0.0" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -1012,20 +944,44 @@
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
+  <Label TextLabel="Hypoxia" GraphId="ae77c">
+    <Graphics CenterX="57.43267031250001" CenterY="1354.1347378124967" Width="90.0" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Endosomal Rab cycles" GraphId="b2a76">
+    <Graphics CenterX="945.88971046875" CenterY="1199.7046687499972" Width="158.58905906249987" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="MON1" GraphId="ba816" GroupRef="ad2de">
+    <Graphics CenterX="1154.86921354788" CenterY="1384.3187967656236" Width="90.0" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" ShapeType="Rectangle" />
+  </Label>
+  <Label TextLabel="In cardiac cells" GraphId="c9688">
+    <Graphics CenterX="418.109839875" CenterY="1405.7603270156249" Width="90.0" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Lysosome biogenesis" GraphId="d41d0" GroupRef="a6b1a">
+    <Graphics CenterX="676.1182268588387" CenterY="1629.8880657830846" Width="128.08592971875012" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="339900" />
+  </Label>
+  <Label TextLabel="Fusion factors" GraphId="d6632">
+    <Graphics CenterX="1003.63037625" CenterY="562.8401690625001" Width="103.70895187499991" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="" GraphId="e992d">
+    <Graphics CenterX="1301.514492937501" CenterY="265.78941504687464" Width="77.16229537499774" Height="20.540573843750735" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="339900" />
+  </Label>
+  <Label TextLabel="Gq signaling" GraphId="f21ab">
+    <Graphics CenterX="58.708951875" CenterY="1456.237262812497" Width="90.0" Height="25.0" ZOrder="28672" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
   <Label TextLabel="Antagonistic binding" GraphId="f764d">
-    <Graphics CenterX="1414.7031601141641" CenterY="144.29838343975138" Width="148.30112470951437" Height="20.0" ZOrder="33030" FillColor="ffffff" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1407.7507448342324" CenterY="138.50470403980853" Width="148.30112470951437" Height="20.0" ZOrder="33030" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
   <Label TextLabel="Legend" GraphId="bf1d2">
     <Graphics CenterX="1286.7887323943667" CenterY="108.33802816901407" Width="80.0" Height="20.0" ZOrder="33032" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
   <Label TextLabel="Agonistic binding" GraphId="cd10d">
-    <Graphics CenterX="1407.969039494613" CenterY="175.49501613067736" Width="148.30112470951437" Height="20.0" ZOrder="33034" FillColor="ffffff" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1400.2701608400844" CenterY="176.65375201066593" Width="138.7584716492928" Height="20.0" ZOrder="33034" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
   <Label TextLabel="Indirect agonistic binding" GraphId="c2f64">
-    <Graphics CenterX="1429.0837974380984" CenterY="205.16758768297498" Width="148.3011247095144" Height="20.0" ZOrder="33038" FillColor="ffffff" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1420.90871131226" CenterY="204.66591568699164" Width="176.2233690816289" Height="20.0" ZOrder="33038" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
   <Label TextLabel="Equal compound" GraphId="fcd8e">
-    <Graphics CenterX="1407.2307168560933" CenterY="238.86042035711122" Width="148.30112470951437" Height="20.0" ZOrder="33040" FillColor="ffffff" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1400.5992572234252" CenterY="236.54294859713409" Width="121.13337488431449" Height="20.0" ZOrder="33040" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
   <Label TextLabel="Ubiquitinated" GraphId="c1b76">
     <Graphics CenterX="1582.6988953635791" CenterY="142.3783793144845" Width="70.4063366262047" Height="19.99999999999999" ZOrder="33044" FillColor="ffffff" FontSize="12" Valign="Middle" />
@@ -1041,6 +997,33 @@
   </Label>
   <Label TextLabel="Pathway" GraphId="edfa7">
     <Graphics CenterX="1385.8257915363824" CenterY="268.9811447031877" Width="96.22232705466644" Height="20.0" ZOrder="33067" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Hypoxia" GraphId="d9f1c">
+    <Graphics CenterX="51.37641156249998" CenterY="753.0331824999969" Width="90.0" Height="25.0" ZOrder="33068" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Hypoxia &#xA;Deporalization" GraphId="bf799">
+    <Graphics CenterX="59.061161562499976" CenterY="688.945182499998" Width="90.0" Height="25.0" ZOrder="33069" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="In tumor cells" GraphId="c950f">
+    <Graphics CenterX="418.7291703906249" CenterY="1517.6075957031203" Width="90.0" Height="25.0" ZOrder="33070" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Misfolding proteins&#xA;mtDNA mutation&#xA;Depolarization" GraphId="d67ec">
+    <Graphics CenterX="61.61411948437501" CenterY="203.18259680468674" Width="115.30878506250005" Height="38.54655907812686" ZOrder="33071" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Non-SLR type&#xA;receptor" GraphId="cf351">
+    <Graphics CenterX="1021.8691620468752" CenterY="704.3055650624981" Width="90.0" Height="25.0" ZOrder="33072" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Outer membrane protein" GraphId="f331d">
+    <Graphics CenterX="867.9913125781245" CenterY="395.36280259374666" Width="142.8314630000008" Height="25.0" ZOrder="33073" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Sequestome-like (SLR)&#xA;receptor" GraphId="f72a3">
+    <Graphics CenterX="1129.3099625000007" CenterY="333.7184031249969" Width="134.79088915625206" Height="25.0" ZOrder="33074" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Ubiquitin E3 ligases" GraphId="cf910">
+    <Graphics CenterX="629.7639538046863" CenterY="75.6992749999971" Width="134.1715586406264" Height="25.0" ZOrder="33075" FillColor="ffffff" FontSize="12" Valign="Middle" />
+  </Label>
+  <Label TextLabel="Parkin" GraphId="cb0f4">
+    <Graphics CenterX="218.761691266629" CenterY="1618.1147687499974" Width="90.0" Height="25.0" ZOrder="33076" FillColor="ffffff" FontSize="12" Valign="Middle" ShapeType="Rectangle" />
   </Label>
   <Shape GraphId="d7161">
     <Attribute Key="org.pathvisio.CellularComponentProperty" Value="Mitochondria" />
@@ -1080,17 +1063,18 @@
   <Shape TextLabel="P" GraphId="c3a1a">
     <Graphics CenterX="1521.748772203109" CenterY="173.03071114861226" Width="20.456069751844762" Height="16.345708660565474" ZOrder="33042" FontSize="12" Valign="Middle" ShapeType="Oval" Rotation="0.0" />
   </Shape>
-  <Group GroupId="eca25" Style="Complex" />
   <Group GroupId="ee791" Style="Group" />
-  <Group GroupId="d0845" Style="Complex" />
   <Group GroupId="eaf28" Style="Group" />
   <Group GroupId="bfb87" Style="Complex" />
   <Group GroupId="f6fd1" GraphId="a1223" Style="Complex" />
   <Group GroupId="fabbf" GraphId="a65a7" Style="Complex" />
+  <Group GroupId="d0845" GraphId="a6f1f" Style="Complex" />
   <Group GroupId="c3fe3" GraphId="a7549" Style="Complex" />
-  <Group GroupId="ebb02" GraphId="ae43c" Style="Group" />
+  <Group GroupId="ad2de" GraphId="a8885" Style="Group" />
   <Group GroupId="dce40" GraphId="b429a" Style="Complex" />
+  <Group GroupId="eca25" GraphId="b4c9a" Style="Complex" />
   <Group GroupId="c0fd0" GraphId="ba63c" Style="Group" />
+  <Group GroupId="a6b1a" GraphId="c1950" Style="Group" />
   <Group GroupId="b5196" GraphId="c55af" Style="Complex" />
   <Group GroupId="bcea4" GraphId="c98c0" Style="Group" />
   <Group GroupId="afacc" GraphId="c9aec" Style="Complex" />
@@ -1100,29 +1084,36 @@
   <Group GroupId="b0bcc" GraphId="d27e0" Style="Complex" />
   <Group GroupId="bf3f4" GraphId="d6456" Style="Complex" />
   <Group GroupId="c5f6e" GraphId="e4a58" Style="Complex" />
-  <Group GroupId="b5b38" GraphId="eaead" Style="Group" />
   <Group GroupId="ea614" GraphId="f2b7f" Style="Group" />
   <Group GroupId="ef8a4" GraphId="f4337" Style="Complex" />
   <Group GroupId="ac50a" GraphId="f95ce" Style="Complex" />
   <InfoBox CenterX="0.0" CenterY="0.0" />
   <Biopax>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="ff7">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26611876</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mitophagy programs: mechanisms and physiological implications of mitochondrial targeting by autophagy.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell Mol Life Sci</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2016</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hamacher-Brady A</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brady NR</bp:AUTHORS>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="c41">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.genome.jp/entry/map04137</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">URL</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mitophagy - animal - Reference pathway</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.kegg.jp/pathway/map04137</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2023</bp:YEAR>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="f85">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25995186</bp:ID>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="c7c">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">27701735</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The three 'P's of mitophagy: PARKIN, PINK1, and post-translational modifications.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genes Dev</bp:SOURCE>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PINK1 in the limelight: multiple functions of an eclectic protein in human health and disease.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Pathol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arena G</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Valente EM</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d16">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25999423</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">How mitochondrial dynamism orchestrates mitophagy.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Circ Res</bp:SOURCE>
       <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2015</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Durcan TM</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fon EA</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shirihai OS</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Song M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dorn GW 2nd</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a5c">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">27443527</bp:ID>
@@ -1135,6 +1126,15 @@
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fon EA</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Durcan TM</bp:AUTHORS>
     </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="ff7">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26611876</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mitophagy programs: mechanisms and physiological implications of mitochondrial targeting by autophagy.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell Mol Life Sci</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2016</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hamacher-Brady A</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Brady NR</bp:AUTHORS>
+    </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="f62">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26882551</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
@@ -1144,15 +1144,6 @@
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yamano K</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Matsuda N</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tanaka K</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="c7c">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">27701735</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PINK1 in the limelight: multiple functions of an eclectic protein in human health and disease.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Pathol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2017</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arena G</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Valente EM</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="f1a">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">27021519</bp:ID>
@@ -1165,12 +1156,14 @@
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nishida K</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Otsu K</bp:AUTHORS>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="c41">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.genome.jp/entry/map04137</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">URL</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mitophagy - animal - Reference pathway</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://www.kegg.jp/pathway/map04137</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2023</bp:YEAR>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="f85">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25995186</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The three 'P's of mitophagy: PARKIN, PINK1, and post-translational modifications.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Genes Dev</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2015</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Durcan TM</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fon EA</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="e08">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25611507</bp:ID>
@@ -1180,16 +1173,6 @@
       <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2015</bp:YEAR>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pickrell AM</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Youle RJ</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d16">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25999423</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">How mitochondrial dynamism orchestrates mitophagy.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Circ Res</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2015</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shirihai OS</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Song M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dorn GW 2nd</bp:AUTHORS>
     </bp:PublicationXref>
   </Biopax>
 </Pathway>


### PR DESCRIPTION
## Summary
- Updated revision of WP5636 (Mitophagy, Homo sapiens) authored by Floor Boereboom.
- Curation cleanup: ~17 free-text annotations that were incorrectly modeled as `<DataNode Type="Pathway">` with empty Xrefs are now proper `<Label>` elements (Hypoxia ×3, Endosomal Rab cycles, Gq signaling, Fusion factors, In cardiac cells, In tumor cells, Lysosome biogenesis, Misfolding proteins/mtDNA mutation/Depolarization, Non-SLR receptor, Sequestome-like (SLR) receptor, Outer membrane protein, Ubiquitin E3 ligases, Parkin orphan, MON1).
- *Autophagy* (Pathway) and *CCZ1* (GeneProduct) retained as DataNodes but moved from groups `b5b38` / `ebb02` into new groups `a6b1a` / `ad2de`.
- Minor layout tweaks (BoardHeight 1733.67 → 1769.16; small coordinate nudges).
- `Version` and `Last-Modified` bumped to `20260520000000`.

## Notes
- No biology changes — interactions, biopax references, description, authors, and organism are unchanged.
- Net: 1196 → 1179 lines (+159 / −176).

## Test plan
- [ ] CI `metadata` job regenerates `pathways/WP5636/WP5636-info.json`, `WP5636-datanodes.tsv`, `WP5636-refs.tsv` (datanode count should drop after Pathway→Label demotions)
- [ ] CI `pubmed` job regenerates `WP5636-bibliography.tsv`
- [ ] CI `frontmatter` job regenerates `WP5636.md`
- [ ] CI `json-svg` job pushes refreshed JSON/SVG/thumb to wikipathways-assets
- [ ] CI `homology-conversion` job pushes refreshed species-mapped GPMLs to wikipathways-homology