### PR TITLE
Added a missing metabolite identifier

### DIFF
--- a/pathways/WP699/WP699.gpml
+++ b/pathways/WP699/WP699.gpml
@@ -60,7 +60,7 @@ Proteins on this pathway have targeted assays available via the [CPTAC Assay Por
   </DataNode>
   <DataNode TextLabel="Aflatoxin B1-6,8-dialcohol" GraphId="d1240" Type="Metabolite">
     <Graphics CenterX="285.0" CenterY="645.0" Width="180.0" Height="20.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />
-    <Xref Database="" ID="" />
+    <Xref Database="PubChem-compound" ID="53297445" />
   </DataNode>
   <DataNode TextLabel="Aflatoxin B1 8,9-dihydrodiol" GraphId="d35ce" Type="Metabolite">
     <Graphics CenterX="290.5" CenterY="339.0" Width="165.0" Height="20.0" ZOrder="32768" FontSize="12" Valign="Middle" Color="0000ff" />


### PR DESCRIPTION

## Pathway Information

**WPID**: WP699__PR78
**TITLE**: Aflatoxin B1 metabolism
**ORGANISM**: Homo sapiens
**DESCRIPTION**: Aflatoxins are naturally occurring [mycotoxins](https://en.wikipedia.org/wiki/Mycotoxin) that are produced by many species of [Aspergillus](https://en.wikipedia.org/wiki/Aspergillus), a [fungus](https://en.wikipedia.org/wiki/Fungus), most notably [Aspergillus flavus](https://en.wikipedia.org/wiki/Aspergillus_flavus) and [Aspergillus parasiticus](https://en.wikipedia.org/wiki/Aspergillus_parasiticus). After entering the body, aflatoxins are metabolized by the liver to a reactive intermediate, aflatoxin M<sub>1</sub>, an [epoxide](https://en.wikipedia.org/wiki/Epoxide). Aflatoxin B1 is considered the most toxic and is produced by both Aspergillus flavus and Aspergillus parasiticus.  Source: [Wikipedia](https://en.wikipedia.org/wiki/Aflatoxin)  Proteins on this pathway have targeted assays available via the [CPTAC Assay Portal](https://assays.cancer.gov/available_assays?wp_id=WP699) 

  *Note: This is an edit to an existing pathway.* 
  

---


Processing...
