### PR TITLE
The title has been updated, and certain protein nodes such as SMAD2/3/7 and SMURF2 had comments that needed to be deleted. 

### DIFF
--- a/pathways/WP5637/WP5637.gpml
+++ b/pathways/WP5637/WP5637.gpml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Pathway xmlns="http://pathvisio.org/GPML/2013a" Name="Draft TGF-B" Version="WP5637_r20260605140817" Author="[MariaChahni, DeSl]" Organism="Homo sapiens" Last-Modified="20260605140817">
+<Pathway xmlns="http://pathvisio.org/GPML/2013a" Name="TGF-β1/SMAD2/3 signalling in decidual NK cells at the fetal-maternal interface" Version="WP5637_r20260605140817" Author="[MariaChahni, DeSl]" Last-Modified="20260605140817" Organism="Homo sapiens">
   <BiopaxRef>d14</BiopaxRef>
   <Graphics BoardWidth="2454.6423751373522" BoardHeight="1086.7164179104477" />
   <DataNode TextLabel="CD9" GraphId="b8698" Type="Protein" GroupRef="ea974">
@@ -31,10 +31,6 @@
     <Graphics CenterX="850.3949986264898" CenterY="229.9396790068087" Width="160.71428571428575" Height="42.59183673469374" ZOrder="32776" FontSize="12" Valign="Middle" ShapeType="Oval" />
     <Xref Database="" ID="4033088" />
   </DataNode>
-  <DataNode TextLabel="GeneProduct" GraphId="e823b" Type="GeneProduct">
-    <Graphics CenterX="1051.0833333333335" CenterY="859.75" Width="16.833333333333425" Height="3.166666666666849" ZOrder="32782" FontSize="12" Valign="Middle" />
-    <Xref Database="" ID="" />
-  </DataNode>
   <DataNode TextLabel="CD56bright tolerogenic dNK phenotype" GraphId="a68a6" Type="Pathway">
     <Graphics CenterX="1641.1478029175594" CenterY="793.254562588556" Width="250.0" Height="36.5" ZOrder="32784" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
     <Xref Database="" ID="" />
@@ -48,7 +44,7 @@
     <Xref Database="Uniprot-TrEMBL" ID="Q15389" />
   </DataNode>
   <DataNode TextLabel="Interleukin 8" GraphId="be428" Type="Metabolite">
-    <Graphics CenterX="1032.6666666666652" CenterY="862.0" Width="90.0" Height="25.0" ZOrder="32790" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="1048.0931639443422" CenterY="862.0000000000003" Width="90.0" Height="25.0" ZOrder="32790" FontSize="12" Valign="Middle" />
     <Xref Database="ChEBI" ID="CHEBI:138181" />
   </DataNode>
   <DataNode TextLabel="DSCs" GraphId="f41da">
@@ -64,7 +60,6 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="Ensembl" ID="ENSG00000105329" />
   </DataNode>
   <DataNode TextLabel="SMAD3" GraphId="aa699" Type="Protein" GroupRef="e1e92">
-    <Comment>https://www.uniprot.org/uniprotkb/P84022/entry</Comment>
     <Graphics CenterX="1282.851825725039" CenterY="514.6057033516452" Width="90.0" Height="25.0" ZOrder="32796" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="P84022" />
   </DataNode>
@@ -144,7 +139,6 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="HGNC" ID="TGFBR1" />
   </DataNode>
   <DataNode TextLabel="SMAD7" GraphId="ff2bb" Type="Protein">
-    <Comment>https://www.uniprot.org/uniprotkb/O15105/entry</Comment>
     <Graphics CenterX="1624.0" CenterY="401.0" Width="90.0" Height="25.0" ZOrder="32831" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="O15105" />
   </DataNode>
@@ -192,7 +186,6 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="HGNC" ID="TGFBR1" />
   </DataNode>
   <DataNode TextLabel="SMAD7" GraphId="f394b" Type="Protein" GroupRef="ff450">
-    <Comment>https://www.uniprot.org/uniprotkb/O15105/entry</Comment>
     <Graphics CenterX="1461.568757789779" CenterY="438.105213959285" Width="61.56958869962528" Height="16.404029912754524" ZOrder="32856" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="O15105" />
   </DataNode>
@@ -201,8 +194,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="Uniprot-TrEMBL" ID="Q9HAU4" />
   </DataNode>
   <DataNode TextLabel="SMAD3" GraphId="f7da6" Type="Protein" GroupRef="a2e13">
-    <Comment>https://www.uniprot.org/uniprotkb/P84022/entry</Comment>
-    <Graphics CenterX="918.0837748458804" CenterY="526.9311803437874" Width="90.0" Height="25.0" ZOrder="32866" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="917.0887499702585" CenterY="526.9311803437874" Width="90.0" Height="25.0" ZOrder="32866" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="P84022" />
   </DataNode>
   <DataNode TextLabel="SMAD4" GraphId="c466f" Type="Protein">
@@ -210,18 +202,15 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="Uniprot-TrEMBL" ID="Q13485" />
   </DataNode>
   <DataNode TextLabel="SMAD2" GraphId="e78f7" Type="Protein" GroupRef="e1db7">
-    <Comment>https://www.uniprot.org/uniprotkb/Q15796/entry</Comment>
     <Graphics CenterX="917.3598691219704" CenterY="399.70110178037646" Width="90.0" Height="25.0" ZOrder="32871" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="Q15796" />
   </DataNode>
   <DataNode TextLabel="SMAD3" GraphId="f8635" Type="Protein" GroupRef="e1db7">
-    <Comment>https://www.uniprot.org/uniprotkb/P84022/entry</Comment>
     <Graphics CenterX="917.3598691219704" CenterY="424.7011017803765" Width="90.0" Height="25.0" ZOrder="32873" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="P84022" />
   </DataNode>
   <DataNode TextLabel="SMAD2" GraphId="e812c" Type="Protein" GroupRef="a2e13">
-    <Comment>https://www.uniprot.org/uniprotkb/Q15796/entry</Comment>
-    <Graphics CenterX="918.0837748458804" CenterY="501.9311803437882" Width="90.0" Height="25.0" ZOrder="32879" FontSize="12" Valign="Middle" />
+    <Graphics CenterX="917.0887499702585" CenterY="501.9311803437882" Width="90.0" Height="25.0" ZOrder="32879" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="Q15796" />
   </DataNode>
   <DataNode TextLabel="SMAD4" GraphId="a9105" Type="Protein" GroupRef="d9997">
@@ -229,7 +218,6 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="Uniprot-TrEMBL" ID="Q13485" />
   </DataNode>
   <DataNode TextLabel="SMAD3" GraphId="e8d1d" Type="Protein" GroupRef="d9997">
-    <Comment>https://www.uniprot.org/uniprotkb/P84022/entry</Comment>
     <Graphics CenterX="1314.9066376850647" CenterY="615.8676167936538" Width="90.0" Height="25.0" ZOrder="32887" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="P84022" />
   </DataNode>
@@ -258,12 +246,10 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Xref Database="Uniprot-TrEMBL" ID="P08637" />
   </DataNode>
   <DataNode TextLabel="SMAD2" GraphId="e1dd2" Type="Protein" GroupRef="d9997">
-    <Comment>https://www.uniprot.org/uniprotkb/Q15796/entry</Comment>
     <Graphics CenterX="1314.9066376850644" CenterY="591.4969431293929" Width="90.0" Height="25.00611374121422" ZOrder="34472" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="Q15796" />
   </DataNode>
   <DataNode TextLabel="SMAD2" GraphId="a7553" Type="Protein" GroupRef="e1e92">
-    <Comment>https://www.uniprot.org/uniprotkb/Q15796/entry</Comment>
     <Graphics CenterX="1192.851825725039" CenterY="514.6057033516452" Width="90.0" Height="25.0" ZOrder="34474" FontSize="12" Valign="Middle" />
     <Xref Database="Uniprot-TrEMBL" ID="Q15796" />
   </DataNode>
@@ -362,7 +348,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <Graphics RelX="1.0" RelY="1.0" Width="15.0" Height="15.0" ShapeType="Oval" />
     <Xref Database="" ID="" />
   </State>
-  <Interaction>
+  <Interaction GraphId="id29aab053">
     <Graphics ConnectorType="Elbow" ZOrder="12288" LineThickness="1.0">
       <Point X="1179.2213860227635" Y="703.0569620253165" GraphRef="e23e3" RelX="0.0" RelY="1.0" />
       <Point X="1079.0" Y="788.5" GraphRef="c57b6" RelX="0.0" RelY="-1.0" ArrowHead="mim-stimulation" />
@@ -370,17 +356,17 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
-  <Interaction>
-    <Graphics ZOrder="12288" LineStyle="Broken" LineThickness="1.0">
-      <Point X="1124.0" Y="801.0" GraphRef="c57b6" RelX="1.0" RelY="0.0" />
-      <Point X="1193.0" Y="801.5" GraphRef="a3335" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
-    </Graphics>
-    <Xref Database="" ID="" />
-  </Interaction>
   <Interaction GraphId="id626842c3">
     <Graphics ZOrder="12288" LineThickness="1.0">
       <Point X="1193.0" Y="809.75" GraphRef="a3335" RelX="-1.0" RelY="0.5" />
-      <Point X="1055.1666666666652" Y="849.5" GraphRef="be428" RelX="0.5" RelY="-1.0" ArrowHead="mim-stimulation" />
+      <Point X="1070.5931639443422" Y="849.5000000000003" GraphRef="be428" RelX="0.5" RelY="-1.0" ArrowHead="mim-stimulation" />
+    </Graphics>
+    <Xref Database="" ID="" />
+  </Interaction>
+  <Interaction GraphId="idaa63bcda">
+    <Graphics ZOrder="12288" LineStyle="Broken" LineThickness="1.0">
+      <Point X="1124.0" Y="801.0" GraphRef="c57b6" RelX="1.0" RelY="0.0" />
+      <Point X="1193.0" Y="801.5" GraphRef="a3335" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -432,7 +418,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
   <Interaction GraphId="ida61e95e8">
     <Graphics ConnectorType="Elbow" ZOrder="12304" LineThickness="1.0">
       <Point X="1287.9352257816515" Y="382.7057723795791" GraphRef="ed8ac" RelX="-0.5" RelY="1.0" />
-      <Point X="917.6389200715989" Y="459.16706101278925" GraphRef="c72e2" RelX="0.0" RelY="0.0" ArrowHead="mim-stimulation" />
+      <Point X="917.2553581970684" Y="459.16706101278925" GraphRef="c72e2" RelX="0.0" RelY="0.0" ArrowHead="mim-stimulation" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -511,7 +497,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
   <Interaction GraphId="idd486f465">
     <BiopaxRef>d24</BiopaxRef>
     <Graphics ZOrder="12328" LineThickness="1.0">
-      <Point X="1032.6666666666652" Y="874.5" GraphRef="be428" RelX="0.0" RelY="1.0" />
+      <Point X="1048.0931639443422" Y="874.5000000000003" GraphRef="be428" RelX="0.0" RelY="1.0" />
       <Point X="1071.3333333333258" Y="986.166666666667" GraphRef="c7822" RelX="-0.5" RelY="-1.0" ArrowHead="mim-stimulation" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -519,7 +505,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
   <Interaction GraphId="id6f400652">
     <Graphics ZOrder="12330" LineThickness="1.0">
       <Point X="917.3598691219704" Y="445.20110178037646" GraphRef="d7e9b" RelX="0.0" RelY="1.0" />
-      <Point X="918.0837748458804" Y="481.4311803437881" GraphRef="f23fe" RelX="0.0" RelY="-1.0" ArrowHead="mim-modification" />
+      <Point X="917.0887499702585" Y="481.4311803437881" GraphRef="f23fe" RelX="0.0" RelY="-1.0" ArrowHead="mim-modification" />
       <Anchor Position="0.3854796839032208" Shape="None" GraphId="c72e2" />
     </Graphics>
     <Xref Database="" ID="" />
@@ -648,14 +634,6 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
-  <Interaction GraphId="df771">
-    <Graphics ZOrder="32854" LineThickness="1.0">
-      <Point X="1272.559496334049" Y="362.3013606148732" GraphRef="ed8ac" RelX="-1.0" RelY="-0.5" />
-      <Point X="1184.0621201169574" Y="362.3013606148732" GraphRef="a875b" RelX="1.0" RelY="-0.5" ArrowHead="mim-modification" />
-      <Anchor Position="0.4" Shape="None" />
-    </Graphics>
-    <Xref Database="" ID="" />
-  </Interaction>
   <Interaction GraphId="f2580">
     <Graphics ZOrder="32860" LineThickness="1.0">
       <Point X="1582.5027004570034" Y="456.7172829248026" GraphRef="b35a5" RelX="0.0" RelY="-1.0" />
@@ -683,7 +661,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
   <Interaction GraphId="b9337">
     <BiopaxRef>d70</BiopaxRef>
     <Graphics ZOrder="32875" LineThickness="1.0">
-      <Point X="971.0837748458804" Y="514.4311803437878" GraphRef="f23fe" RelX="1.0" RelY="0.0" />
+      <Point X="970.0887499702585" Y="514.4311803437878" GraphRef="f23fe" RelX="1.0" RelY="0.0" />
       <Point X="1135.851825725039" Y="514.6057033516452" GraphRef="f67ab" RelX="-1.0" RelY="0.0" ArrowHead="mim-binding" />
       <Anchor Position="0.4" Shape="None" GraphId="a311c" />
     </Graphics>
@@ -693,16 +671,7 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     <BiopaxRef>d70</BiopaxRef>
     <Graphics ZOrder="32877" LineThickness="1.0">
       <Point X="1036.9311373599103" Y="545.715901190601" GraphRef="c466f" RelX="0.0" RelY="-1.0" />
-      <Point X="1036.9909951975437" Y="514.5009895469308" GraphRef="a311c" RelX="0.0" RelY="0.0" ArrowHead="mim-binding" />
-    </Graphics>
-    <Xref Database="" ID="" />
-  </Interaction>
-  <Interaction GraphId="id66f6fd34">
-    <Graphics ConnectorType="Elbow" ZOrder="34462" LineThickness="1.0">
-      <Point X="1107.9999999999923" Y="1011.166666666667" GraphRef="c7822" RelX="0.0" RelY="1.0" />
-      <Point X="1568.6669017315292" Y="1034.0" />
-      <Point X="2029.333803463066" Y="583.6615887014068" />
-      <Point X="2049.333803463066" Y="133.32317740281349" GraphRef="fa556" RelX="-1.0" RelY="-0.5" ArrowHead="Arrow" />
+      <Point X="1036.3939802721707" Y="514.5009895469308" GraphRef="a311c" RelX="0.0" RelY="0.0" ArrowHead="mim-binding" />
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
@@ -756,6 +725,12 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
     </Graphics>
     <Xref Database="" ID="" />
   </Interaction>
+  <GraphicalLine GraphId="b64e4">
+    <Graphics ConnectorType="Elbow" ZOrder="34462" LineThickness="1.0">
+      <Point X="1107.9999999999923" Y="1011.166666666667" GraphRef="c7822" RelX="0.0" RelY="1.0" />
+      <Point X="2049.333803463066" Y="143.94817740281349" GraphRef="fa556" RelX="-1.0" RelY="0.0" ArrowHead="Arrow" />
+    </Graphics>
+  </GraphicalLine>
   <Label TextLabel="EVT cells" GraphId="e7ecf">
     <Graphics CenterX="2049.5004701297257" CenterY="245.19817740281738" Width="90.0" Height="25.0" ZOrder="34404" FillColor="ffffff" FontSize="12" Valign="Middle" />
   </Label>
@@ -1116,6 +1091,69 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
   <Group GroupId="e1e92" GraphId="f67ab" Style="Complex" />
   <InfoBox CenterX="0.0" CenterY="0.0" />
   <Biopax>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="bbf">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">34049032</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decidual stromal cells support tolerance at the human foetal-maternal interface by inducing regulatory M2 macrophages and regulatory T-cells.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Reprod Immunol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2021</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lindau R</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vondra S</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spreckels J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solders M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Svensson-Arvelund J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Berg G</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pollheimer J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kaipe H</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jenmalm MC</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ernerudh J</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a39">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">31681264</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dynamic Function and Composition Changes of Immune Cells During Normal and Pathological Pregnancy at the Maternal-Fetal Interface.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Front Immunol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2019</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yang F</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zheng Q</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jin L</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a38">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11163210</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Smad7 binds to Smurf2 to form an E3 ubiquitin ligase that targets the TGF beta receptor for degradation.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mol Cell</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2000</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kavsak P</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rasmussen RK</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Causing CG</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bonni S</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhu H</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thomsen GH</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wrana JL</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="ad5">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26907385</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Role of decidual CD14(+) macrophages in the homeostasis of maternal-fetal interface and the differentiation capacity of the cells during pregnancy and parturition.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placenta</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2016</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang H</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">He M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hou Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chen S</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang X</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ji X</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="baa">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25023688</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural killer cells and regulatory T cells in early pregnancy loss.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Int J Dev Biol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sharma S</bp:AUTHORS>
+    </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d01">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">16816146</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
@@ -1130,6 +1168,35 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Searle RF</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Robson SC</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bulmer JN</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="b38">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">38009061</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endometrial TGFβ signaling fosters early pregnancy development by remodeling the fetomaternal interface.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Am J Reprod Immunol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2023</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parks SE</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geng T</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monsivais D</bp:AUTHORS>
+    </bp:PublicationXref>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="b28">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">23973270</bp:ID>
+      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decidual cell regulation of natural killer cell-recruiting chemokines: implications for the pathogenesis and prediction of preeclampsia.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Am J Pathol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2013</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lockwood CJ</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huang SJ</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chen CP</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huang Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xu J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Faramarzi S</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kayisli O</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kayisli U</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Koopman L</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Smedts D</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Buchwalder LF</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schatz F</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d70">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">40119192</bp:ID>
@@ -1168,63 +1235,49 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">López-Botet M</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Muntasell A</bp:AUTHORS>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="b38">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">38009061</bp:ID>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d24">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">16892062</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endometrial TGFβ signaling fosters early pregnancy development by remodeling the fetomaternal interface.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Am J Reprod Immunol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2023</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parks SE</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geng T</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monsivais D</bp:AUTHORS>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decidual NK cells regulate key developmental processes at the human fetal-maternal interface.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nat Med</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2006</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hanna J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Goldman-Wohl D</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hamani Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Avraham I</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Greenfield C</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natanson-Yaron S</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prus D</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cohen-Daniel L</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arnon TI</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manaster I</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gazit R</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yutkin V</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Benharroch D</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Porgador A</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Keshet E</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yagel S</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mandelboim O</bp:AUTHORS>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a5d">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">17360654</bp:ID>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="c28">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">32291850</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGFbeta promotes conversion of CD16+ peripheral blood NK cells into CD16- NK cells with similarities to decidual NK cells.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Proc Natl Acad Sci U S A</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2007</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Keskin DB</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allan DS</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rybalov B</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Andzelm MM</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stern JN</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kopcow HD</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Koopman LA</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Strominger JL</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a38">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11163210</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Smad7 binds to Smurf2 to form an E3 ubiquitin ligase that targets the TGF beta receptor for degradation.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mol Cell</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2000</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kavsak P</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rasmussen RK</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Causing CG</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bonni S</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhu H</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thomsen GH</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wrana JL</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d14">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">18768831</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGF-beta utilizes SMAD3 to inhibit CD16-mediated IFN-gamma production and antibody-dependent cellular cytotoxicity in human NK cells.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Immunol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2008</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trotta R</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dal Col J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yu J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ciarlariello D</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thomas B</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang X</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allard J 2nd</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wei M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mao H</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Byrd JC</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Perrotti D</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Caligiuri MA</bp:AUTHORS>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placental endovascular extravillous trophoblasts (enEVTs) educate maternal T-cell differentiation along the maternal-placental circulation.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell Prolif</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ma Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yang Q</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fan M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang L</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gu Y</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jia W</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li Z</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang F</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li YX</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li R</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shao X</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang YL</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="cd7">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></bp:ID>
@@ -1253,44 +1306,24 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ofer Mandelboim</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ido Amit</bp:AUTHORS>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="c28">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">32291850</bp:ID>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d14">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">18768831</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placental endovascular extravillous trophoblasts (enEVTs) educate maternal T-cell differentiation along the maternal-placental circulation.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell Prolif</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2020</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ma Y</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yang Q</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fan M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang L</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gu Y</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jia W</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li Z</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang F</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li YX</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Li R</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shao X</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang YL</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="b28">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">23973270</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decidual cell regulation of natural killer cell-recruiting chemokines: implications for the pathogenesis and prediction of preeclampsia.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Am J Pathol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2013</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lockwood CJ</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huang SJ</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chen CP</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Huang Y</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Xu J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Faramarzi S</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kayisli O</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kayisli U</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Koopman L</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Smedts D</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Buchwalder LF</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schatz F</bp:AUTHORS>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGF-beta utilizes SMAD3 to inhibit CD16-mediated IFN-gamma production and antibody-dependent cellular cytotoxicity in human NK cells.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Immunol</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2008</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trotta R</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dal Col J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yu J</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ciarlariello D</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thomas B</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang X</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allard J 2nd</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wei M</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mao H</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Byrd JC</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Perrotti D</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Caligiuri MA</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="bc4">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">23487420</bp:ID>
@@ -1307,71 +1340,6 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sukhatme VP</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karumanchi SA</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kopcow HD</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a39">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">31681264</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dynamic Function and Composition Changes of Immune Cells During Normal and Pathological Pregnancy at the Maternal-Fetal Interface.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Front Immunol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2019</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yang F</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zheng Q</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jin L</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="ad5">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">26907385</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Role of decidual CD14(+) macrophages in the homeostasis of maternal-fetal interface and the differentiation capacity of the cells during pregnancy and parturition.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placenta</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2016</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wang H</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">He M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hou Y</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chen S</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang X</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zhang M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ji X</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d24">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">16892062</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decidual NK cells regulate key developmental processes at the human fetal-maternal interface.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nat Med</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2006</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hanna J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Goldman-Wohl D</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hamani Y</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Avraham I</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Greenfield C</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natanson-Yaron S</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prus D</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cohen-Daniel L</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arnon TI</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Manaster I</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gazit R</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yutkin V</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Benharroch D</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Porgador A</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Keshet E</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Yagel S</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mandelboim O</bp:AUTHORS>
-    </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="bbf">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">34049032</bp:ID>
-      <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decidual stromal cells support tolerance at the human foetal-maternal interface by inducing regulatory M2 macrophages and regulatory T-cells.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">J Reprod Immunol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2021</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lindau R</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vondra S</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spreckels J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Solders M</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Svensson-Arvelund J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Berg G</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pollheimer J</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kaipe H</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Jenmalm MC</bp:AUTHORS>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ernerudh J</bp:AUTHORS>
     </bp:PublicationXref>
     <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="d75">
       <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">22992590</bp:ID>
@@ -1395,13 +1363,20 @@ http://purl.obolibrary.org/obo/CL_2000002 ;
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carlyle JR</bp:AUTHORS>
       <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Strominger JL</bp:AUTHORS>
     </bp:PublicationXref>
-    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="baa">
-      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">25023688</bp:ID>
+    <bp:PublicationXref xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:id="a5d">
+      <bp:ID rdf:datatype="http://www.w3.org/2001/XMLSchema#string">17360654</bp:ID>
       <bp:DB rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PubMed</bp:DB>
-      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural killer cells and regulatory T cells in early pregnancy loss.</bp:TITLE>
-      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Int J Dev Biol</bp:SOURCE>
-      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014</bp:YEAR>
-      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sharma S</bp:AUTHORS>
+      <bp:TITLE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGFbeta promotes conversion of CD16+ peripheral blood NK cells into CD16- NK cells with similarities to decidual NK cells.</bp:TITLE>
+      <bp:SOURCE rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Proc Natl Acad Sci U S A</bp:SOURCE>
+      <bp:YEAR rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2007</bp:YEAR>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Keskin DB</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allan DS</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rybalov B</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Andzelm MM</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stern JN</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kopcow HD</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Koopman LA</bp:AUTHORS>
+      <bp:AUTHORS rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Strominger JL</bp:AUTHORS>
     </bp:PublicationXref>
   </Biopax>
 </Pathway>

--- a/pathways/WP5637/WP5637.gpml
+++ b/pathways/WP5637/WP5637.gpml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Pathway xmlns="http://pathvisio.org/GPML/2013a" Name="TGF-β1/SMAD2/3 signalling in decidual NK cells at the fetal-maternal interface" Version="WP5637_r20260605140817" Author="[MariaChahni, DeSl]" Last-Modified="20260605140817" Organism="Homo sapiens">
+<Pathway xmlns="http://pathvisio.org/GPML/2013a" Name="TGF-β1/SMAD2/3 signalling in decidual NK cells at the fetal-maternal interface" Version="WP5637_r20260605140817" Author="[MariaChahni, DeSl]" Last-Modified="20260615073400" Organism="Homo sapiens">
   <BiopaxRef>d14</BiopaxRef>
   <Graphics BoardWidth="2454.6423751373522" BoardHeight="1086.7164179104477" />
   <DataNode TextLabel="CD9" GraphId="b8698" Type="Protein" GroupRef="ea974">


### PR DESCRIPTION
I have updated the title of the pathway and removed comments with links to the identifiers of certain proteins such as SMAD2/3/7 and SMURF2. I also deleted a node which was hidden behind another that was mistakenly there, and updated the line type of the arrow connecting the trophoblast invasion node to the visualization of trophoblast invasion.