### PR TITLE
Update WP4010 Fatty Acid Lysis node to KE327

### DIFF
--- a/pathways/WP4010/WP4010.gpml
+++ b/pathways/WP4010/WP4010.gpml
@@ -151,9 +151,9 @@ Adverse outcome pathway liver steatosis; the accumulation of lipids in hepatocyt
     <Graphics CenterX="564.8674444803369" CenterY="177.60937373975975" Width="202.95868772782455" Height="30.250000000000018" ZOrder="32768" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />
     <Xref Database="WikiPathways" ID="WP2876" />
   </DataNode>
-  <DataNode TextLabel="KE10106: Fatty Acid Lysis" GraphId="e65ba" Type="Event">
+  <DataNode TextLabel="KE327: Accumulation, Fatty acid" GraphId="e65ba" Type="Event">
     <Graphics CenterX="1645.7327394370623" CenterY="1081.6578943946758" Width="175.5815152122146" Height="30.250000000000018" ZOrder="32768" FontSize="12" Valign="Middle" />
-    <Xref Database="AOP-Wiki KE" ID="10106" />
+    <Xref Database="AOP-Wiki KE" ID="327" />
   </DataNode>
   <DataNode TextLabel="Constitutive Androstane Receptor Pathway" GraphId="e7155" Type="Pathway">
     <Graphics CenterX="968.371467025572" CenterY="177.60937373975975" Width="316.2853297442798" Height="30.250000000000018" ZOrder="32768" FontWeight="Bold" FontSize="12" Valign="Middle" ShapeType="RoundedRectangle" Color="14961e" />


### PR DESCRIPTION
WP4010 (liver steatosis AOP) has one Event node whose AOP-Wiki xref doesn't resolve. The node is "KE10106: Fatty Acid Lysis", xref AOP-Wiki KE:10106. That ID returns no title from the AOP-Wiki RDF endpoint, belongs to no AOP, and aopwiki.org/events/10106 redirects to the event index. There is no fatty-acid-lysis KE in AOP-Wiki at all; the nearest is KE2408 "Increase, Adipose lipolysis", which isn't in any of the steatosis AOPs. The other 24 Event xrefs in WP4010 all resolve.

The node's position suggests what it should be. It sits between KE860 (decreased mitochondrial fatty acid beta-oxidation) and KE291 (accumulation, triglyceride). AOP 60 has KE327 "Accumulation, Fatty acid" in exactly that slot, downstream of KE179 (Decrease, Fatty acid beta-oxidation). So KE327 looks like the intended target.

This changes the label to "KE327: Accumulation, Fatty acid" and the xref ID to 327. GPML only, since the derived files regenerate from it.